### PR TITLE
Allow compilation errors to show up at runtime

### DIFF
--- a/tools/protovalidate-conformance/internal/results/result.go
+++ b/tools/protovalidate-conformance/internal/results/result.go
@@ -161,6 +161,8 @@ func (c compilationErrorResult) IsSuccessWith(other Result, strict bool) bool {
 		return res.IsSuccessWith(c, strict)
 	case compilationErrorResult:
 		return true
+	case runtimeErrorResult:
+		return !strict
 	default:
 		return false
 	}


### PR DESCRIPTION
When not --strict