### PR TITLE
Bugfix expected failures flag ux

### DIFF
--- a/.ijwb/.bazelproject
+++ b/.ijwb/.bazelproject
@@ -1,4 +1,0 @@
-directories:
-  .
-
-derive_targets_from_directories: false

--- a/.ijwb/.bazelproject
+++ b/.ijwb/.bazelproject
@@ -1,0 +1,4 @@
+directories:
+  .
+
+derive_targets_from_directories: false

--- a/tools/protovalidate-conformance/config.go
+++ b/tools/protovalidate-conformance/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	flag "github.com/spf13/pflag"
+    "gopkg.in/yaml.v3"
 )
 
 type config struct {

--- a/tools/protovalidate-conformance/config.go
+++ b/tools/protovalidate-conformance/config.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	flag "github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
 )
 
 type config struct {
@@ -68,7 +67,7 @@ func parseFlags() (*config, error) {
 	flag.BoolVar(&cfg.proto, "proto", cfg.proto, "return results as binary serialized proto to stdout")
 	flag.BoolVar(&cfg.dump, "dump", cfg.dump, "output the expected results, without a command")
 	flag.IntVar(&cfg.benchmark, "benchmark", cfg.benchmark, "run benchmarks")
-	flag.StringVar(&cfg.expectedFailureFile, "expected-failures", cfg.expectedFailureFile, "yaml file containing list of expected failures")
+	flag.StringVar(&cfg.expectedFailureFile, "expected_failures", cfg.expectedFailureFile, "yaml file containing list of expected failures")
 	flag.Parse()
 
 	cfg.print = !cfg.json && !cfg.proto

--- a/tools/protovalidate-conformance/config.go
+++ b/tools/protovalidate-conformance/config.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	flag "github.com/spf13/pflag"
-    "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 type config struct {


### PR DESCRIPTION
Other flags use an underscore with multi-word flags, expected-failures uses a hyphen. This change repairs this oversight