### PR TITLE
Fix field path for uint-typed map keys

### DIFF
--- a/tools/protovalidate-conformance/internal/cases/cases_map.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_map.go
@@ -196,7 +196,7 @@ func mapSuite() suites.Suite {
 			Message: &cases.MapRecursive{Val: map[uint32]*cases.MapRecursive_Msg{1: {}}},
 			Expected: results.Violations(
 				&validate.Violation{
-					FieldPath:    "val[0x1].val",
+					FieldPath:    "val[1].val",
 					ConstraintId: "string.min_len",
 					Message:      "value length must be at least 3 characters",
 				},


### PR DESCRIPTION
Go's formatter prints uint-type values as a hex literal when using the `%#v` directive in `fmt.Sprintf`, which bled over into the test cases. This patch makes it a standard decimal literal. Updates in the libraries will follow.