### PR TITLE
Update buf.lock for protovalidate-testing

### DIFF
--- a/proto/protovalidate-testing/buf.lock
+++ b/proto/protovalidate-testing/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: bufbuild
     repository: protovalidate
-    commit: 890d7e3584ce4bb29af9fe953393a3a2
-    digest: shake256:878c6bf315f37310a6315de26f409548d2951b9f8f042a8a599973496fd0298680554dba152924264b9c41f5bd05adbc4b3fcedfc2156e1707006f45fddd9db0
+    commit: f9bf3460ccf141d68ba17653f5ef85dc
+    digest: shake256:d763cdb6df6ec05e0859db78e0645a43603d06f0263d4dce59077de8c04c788b3e949c9a08f7769b296c2408d3039631f516cec0f43d0dbc052421c332700769


### PR DESCRIPTION
protovalidate-testing requires the new FloatRules.finite field to compile, so we need to update the buf.lock file to include it.