### PR TITLE
Add link to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository is the core of the `protovalidate` project. It contains:
 - [The API definition](proto/protovalidate/buf/validate/validate.proto): used to describe validation constraints
 - [Documentation](docs): how to apply `protovalidate` effectively
 - [Migration tooling](docs/migrate.md): incrementally migrate from `protoc-gen-validate`
+- [Examples](examples): example `.proto` files using `protovalidate`
 - [Conformance testing utilities](docs/conformance.md): for acceptance testing of `protovalidate` implementations
 
 Runtime implementations of `protovalidate` can be found in their own repositories:
@@ -180,6 +181,8 @@ For more advanced or custom constraints, `protovalidate` allows for CEL expressi
      }];
    }
    ```
+
+Check out [`examples`](examples) for examples on both standard constraints and custom CEL constraints.
 
 ### Validate Messages
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,28 @@
+# Examples
+
+This directory has examples for protovalidate.
+
+## Standard Constraints
+
+`rule_*.proto` has protovalidate examples based on options.
+
+To get started, checkout the following examples:
+
+- [`option_number.proto`](option_number.proto)
+- [`option_string.proto`](option_string.proto)
+- [`option_repeated.proto`](option_repeated.proto)
+
+The complete set of options can be found [here](../proto/protovalidate/buf/validate/validate.proto).
+
+## Custom Constraints
+
+`cel_*.proto` has protovalidate examples that validate with CEL expressions.
+
+To get started, checkout the following examples:
+
+- [`cel_field_access.proto`](cel_field_access.proto)
+- [`cel_conditional_operator.proto`](cel_conditional_operator.proto)
+- [`cel_field_presence.proto`](cel_field_presence.proto)
+
+The langugage specification can be found [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
+

--- a/examples/examples.md
+++ b/examples/examples.md
@@ -1,8 +1,0 @@
-# Examples
-
-This directory has examples for protovalidate. `rule_*.proto` has protovalidate examples based on custom options. The complete set of options can be found [here](<(proto/protovalidate/buf/validate/validate.proto)>) .`cel_*.proto` has protovalidate examples that validate with CEL. The langugage specification can be found [here](https://github.com/google/cel-spec).
-
-To get started, checkout the following examples:
-
-- `option_oneof.proto`
-- `cel_field_access.proto`


### PR DESCRIPTION
Also replaced `examples/examples.md` with `examples/README.md`.