### PR TITLE
Add note about required repeated fields and update indentation

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -145,9 +145,8 @@ message FieldConstraints {
   // this field must be set. If required is set to true, the field value must
   // not be empty; otherwise, an error message will be generated.
   //
-  // Note that `required` does *not* validate that repeated fields are non-empty.
-  // If you'd like to validate that a `repeated` field is non-empty, use
-  // `repeated.min_items = 1`.
+  // Note that `required` validates that `repeated` fields are non-empty, that is
+  // setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
   //
   // ```proto
   // message MyMessage {
@@ -3172,6 +3171,8 @@ message EnumRules {
 message RepeatedRules {
   // `min_items` requires that this field must contain at least the specified
   // minimum number of items.
+  //
+  // Note that `min_items = 1` is equivalent to setting a field as `required`.
   //
   // ```proto
   // message MyRepeated {

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -60,7 +60,7 @@ extend google.protobuf.FieldOptions {
 // MessageConstraints represents validation rules that are applied to the entire message.
 // It includes disabling options and a list of Constraint messages representing Common Expression Language (CEL) validation rules.
 message MessageConstraints {
-  // disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+  // `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
   // This includes any fields within the message that would otherwise support validation.
   //
   // ```proto
@@ -71,22 +71,22 @@ message MessageConstraints {
   // ```
   optional bool disabled = 1;
 
-  // cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+  // `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
   // These constraints are written in Common Expression Language (CEL) syntax. For more information on
   // CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
   //
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `foo` must be greater than 42.
-  //  option (buf.validate.message).cel = {
-  //    id: "my_message.value",
-  //    message: "value must be greater than 42",
-  //    expression: "this.foo > 42",
-  //  };
-  //  optional int32 foo = 1;
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `foo` must be greater than 42.
+  //   option (buf.validate.message).cel = {
+  //     id: "my_message.value",
+  //     message: "value must be greater than 42",
+  //     expression: "this.foo > 42",
+  //   };
+  //   optional int32 foo = 1;
+  // }
+  // ```
   repeated Constraint cel = 3;
 }
 
@@ -95,73 +95,77 @@ message MessageConstraints {
 // that exactly one of the fields within a oneof is set; validation will fail
 // if none of the fields in the oneof are set:
 message OneofConstraints {
-  //`required` is an optional boolean attribute that ensures that
-  //exactly one of the field options in a oneof is set; validation fails if
-  //no fields in the oneof are set.
+  // `required` is an optional boolean attribute that ensures that
+  // exactly one of the field options in a oneof is set; validation fails if
+  // no fields in the oneof are set.
   //
-  //```proto
-  //message MyMessage {
-  //  oneof value {
-  //    // The field `a` or `b` must be set.
-  //    option (buf.validate.oneof).required = true;
-  //    optional string a = 1;
-  //    optional string b = 2;
-  //  }
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   oneof value {
+  //     // The field `a` or `b` must be set.
+  //     option (buf.validate.oneof).required = true;
+  //     optional string a = 1;
+  //     optional string b = 2;
+  //   }
+  // }
+  // ```
   optional bool required = 1;
 }
 
 // FieldRules encapsulates the rules for each type of field. Depending on the
 // field, the correct set should be used to ensure proper validations.
 message FieldConstraints {
-  // `Constraint` is a repeated field used to represent a textual expression
+  // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information on
   // CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must be greater than 42.
-  //  optional int32 value = 1 [(buf.validate.field).cel = {
-  //    id: "my_message.value",
-  //    message: "value must be greater than 42",
-  //    expression: "this > 42",
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must be greater than 42.
+  //   optional int32 value = 1 [(buf.validate.field).cel = {
+  //     id: "my_message.value",
+  //     message: "value must be greater than 42",
+  //     expression: "this > 42",
+  //   }];
+  // }
+  // ```
   repeated Constraint cel = 23;
-  //`skipped` is an optional boolean attribute that specifies that the
-  //validation rules of this field should not be evaluated. If skipped is set to
-  //true, any validation rules set for the field will be ignored.
+  // `skipped` is an optional boolean attribute that specifies that the
+  // validation rules of this field should not be evaluated. If skipped is set to
+  // true, any validation rules set for the field will be ignored.
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must not be set.
-  //  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must not be set.
+  //   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+  // }
+  // ```
   bool skipped = 24;
-  //`required` is an optional boolean attribute that specifies that
-  //this field must be set. If required is set to true, the field value must
-  //not be empty; otherwise, an error message will be generated.
+  // `required` is an optional boolean attribute that specifies that
+  // this field must be set. If required is set to true, the field value must
+  // not be empty; otherwise, an error message will be generated.
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must be set.
-  //  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-  //}
-  //```
+  // Note that `required` does *not* validate that repeated fields are non-empty.
+  // If you'd like to validate that a `repeated` field is non-empty, use
+  // `repeated.min_items = 1`.
+  //
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must be set.
+  //   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+  // }
+  // ```
   bool required = 25;
-  //`ignore_empty` specifies that the validation rules of this field should be
-  //evaluated only if the field isn't empty. If the field is empty, no validation
-  //rules are applied.
+  // `ignore_empty` specifies that the validation rules of this field should be
+  // evaluated only if the field isn't empty. If the field is empty, no validation
+  // rules are applied.
   //
-  //```proto
-  //message MyRepeated {
-  //  // The field `value` validation rules should be evaluated only if the field isn't empty.
-  //  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // The field `value` validation rules should be evaluated only if the field isn't empty.
+  //   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+  // }
+  // ```
   bool ignore_empty = 26;
   oneof type {
     // Scalar Field Types
@@ -196,31 +200,31 @@ message FieldConstraints {
 // FloatRules describes the constraints applied to `float` values. These
 // rules may also be applied to the `google.protobuf.FloatValue` Well-Known-Type.
 message FloatRules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must equal 42.0
+  // ```proto
+  // message MyFloat {
+  //   // value must equal 42.0
   //   float value = 1 [(buf.validate.field).float.const = 42.0];
-  //}
-  //```
+  // }
+  // ```
   optional float const = 1 [(priv.field).cel = {
     id: "float.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
 
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be less than 10.0
+    // ```proto
+    // message MyFloat {
+    //   // value must be less than 10.0
     //   float value = 1 [(buf.validate.field).float.lt = 10.0];
-    //}
-    //```
+    // }
+    // ```
     float lt = 2 [(priv.field).cel = {
       id: "float.lt",
       expression:
@@ -228,16 +232,16 @@ message FloatRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be less than or equal to 10.0
+    // ```proto
+    // message MyFloat {
+    //   // value must be less than or equal to 10.0
     //   float value = 1 [(buf.validate.field).float.lte = 10.0];
-    //}
-    //```
+    // }
+    // ```
     float lte = 3 [(priv.field).cel = {
       id: "float.lte",
       expression:
@@ -247,24 +251,24 @@ message FloatRules {
   }
 
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be greater than 5.0 [float.gt]
-    //  float value = 1 [(buf.validate.field).float.gt = 5.0];
+    // ```proto
+    // message MyFloat {
+    //   // value must be greater than 5.0 [float.gt]
+    //   float value = 1 [(buf.validate.field).float.gt = 5.0];
     //
-    //  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-    //  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+    //   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+    //   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-    //  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+    //   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+    // }
+    // ```
     float gt = 4 [
       (priv.field).cel = {
         id: "float.gt",
@@ -298,24 +302,24 @@ message FloatRules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be greater than or equal to 5.0 [float.gte]
-    //  float value = 1 [(buf.validate.field).float.gte = 5.0];
+    // ```proto
+    // message MyFloat {
+    //   // value must be greater than or equal to 5.0 [float.gte]
+    //   float value = 1 [(buf.validate.field).float.gte = 5.0];
     //
-    //  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-    //  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+    //   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+    //   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-    //  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+    //   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+    // }
+    // ```
     float gte = 5 [
       (priv.field).cel = {
         id: "float.gte",
@@ -350,37 +354,37 @@ message FloatRules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must be in list [1.0, 2.0, 3.0]
-  //  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyFloat {
+  //   // value must be in list [1.0, 2.0, 3.0]
+  //   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated float in = 6 [(priv.field).cel = {
     id: "float.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`in` requires the field value to not be equal to any of the specified
+  // `in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must not be in list [1.0, 2.0, 3.0]
-  //  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyFloat {
+  //   // value must not be in list [1.0, 2.0, 3.0]
+  //   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated float not_in = 7 [(priv.field).cel = {
     id: "float.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
   }];
 
-  //`finite` requires the field value to be finite. If the field value is
+  // `finite` requires the field value to be finite. If the field value is
   // infinite or NaN, an error message is generated.
   bool finite = 8 [(priv.field).cel = {
     id: "float.finite",
@@ -391,15 +395,15 @@ message FloatRules {
 // DoubleRules describes the constraints applied to `double` values. These
 // rules may also be applied to the `google.protobuf.DoubleValue` Well-Known-Type.
 message DoubleRules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must equal 42.0
+  // ```proto
+  // message MyDouble {
+  //   // value must equal 42.0
   //   double value = 1 [(buf.validate.field).double.const = 42.0];
-  //}
-  //```
+  // }
+  // ```
   optional double const = 1 [(priv.field).cel = {
     id: "double.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -409,12 +413,12 @@ message DoubleRules {
     // value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be less than 10.0
+    // ```proto
+    // message MyDouble {
+    //   // value must be less than 10.0
     //   double value = 1 [(buf.validate.field).double.lt = 10.0];
-    //}
-    //```
+    // }
+    // ```
     double lt = 2 [(priv.field).cel = {
       id: "double.lt",
       expression:
@@ -422,16 +426,16 @@ message DoubleRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified value
+    // `lte` requires the field value to be less than or equal to the specified value
     // (field <= value). If the field value is greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be less than or equal to 10.0
+    // ```proto
+    // message MyDouble {
+    //   // value must be less than or equal to 10.0
     //   double value = 1 [(buf.validate.field).double.lte = 10.0];
-    //}
-    //```
+    // }
+    // ```
     double lte = 3 [(priv.field).cel = {
       id: "double.lte",
       expression:
@@ -446,18 +450,18 @@ message DoubleRules {
     // range. If the field value doesn't meet the required conditions, an error
     // message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be greater than 5.0 [double.gt]
-    //  double value = 1 [(buf.validate.field).double.gt = 5.0];
+    // ```proto
+    // message MyDouble {
+    //   // value must be greater than 5.0 [double.gt]
+    //   double value = 1 [(buf.validate.field).double.gt = 5.0];
     //
-    //  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-    //  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+    //   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+    //   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-    //  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+    //   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+    // }
+    // ```
     double gt = 4 [
       (priv.field).cel = {
         id: "double.gt",
@@ -497,18 +501,18 @@ message DoubleRules {
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be greater than or equal to 5.0 [double.gte]
-    //  double value = 1 [(buf.validate.field).double.gte = 5.0];
+    // ```proto
+    // message MyDouble {
+    //   // value must be greater than or equal to 5.0 [double.gte]
+    //   double value = 1 [(buf.validate.field).double.gte = 5.0];
     //
-    //  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-    //  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+    //   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+    //   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-    //  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+    //   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+    // }
+    // ```
     double gte = 5 [
       (priv.field).cel = {
         id: "double.gte",
@@ -546,33 +550,33 @@ message DoubleRules {
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must be in list [1.0, 2.0, 3.0]
-  //  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyDouble {
+  //   // value must be in list [1.0, 2.0, 3.0]
+  //   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated double in = 6 [(priv.field).cel = {
     id: "double.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must not be in list [1.0, 2.0, 3.0]
-  //  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyDouble {
+  //   // value must not be in list [1.0, 2.0, 3.0]
+  //   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated double not_in = 7 [(priv.field).cel = {
     id: "double.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
   }];
 
-  //`finite` requires the field value to be finite. If the field value is
+  // `finite` requires the field value to be finite. If the field value is
   // infinite or NaN, an error message is generated.
   bool finite = 8 [(priv.field).cel = {
     id: "double.finite",
@@ -583,15 +587,15 @@ message DoubleRules {
 // Int32Rules describes the constraints applied to `int32` values. These
 // rules may also be applied to the `google.protobuf.Int32Value` Well-Known-Type.
 message Int32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyInt32 {
+  //   // value must equal 42
   //   int32 value = 1 [(buf.validate.field).int32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional int32 const = 1 [(priv.field).cel = {
     id: "int32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -601,12 +605,12 @@ message Int32Rules {
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyInt32 {
+    //   // value must be less than 10
     //   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     int32 lt = 2 [(priv.field).cel = {
       id: "int32.lt",
       expression:
@@ -614,16 +618,16 @@ message Int32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyInt32 {
+    //   // value must be less than or equal to 10
     //   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     int32 lte = 3 [(priv.field).cel = {
       id: "int32.lte",
       expression:
@@ -632,24 +636,24 @@ message Int32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be greater than 5 [int32.gt]
-    //  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+    // ```proto
+    // message MyInt32 {
+    //   // value must be greater than 5 [int32.gt]
+    //   int32 value = 1 [(buf.validate.field).int32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [int32.gt_lt]
-    //  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [int32.gt_lt]
+    //   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-    //  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+    //   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     int32 gt = 4 [
       (priv.field).cel = {
         id: "int32.gt",
@@ -683,24 +687,24 @@ message Int32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified value
+    // `gte` requires the field value to be greater than or equal to the specified value
     // (exclusive). If the value of `gte` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be greater than or equal to 5 [int32.gte]
-    //  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+    // ```proto
+    // message MyInt32 {
+    //   // value must be greater than or equal to 5 [int32.gte]
+    //   int32 value = 1 [(buf.validate.field).int32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-    //  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+    //   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-    //  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+    //   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     int32 gte = 5 [
       (priv.field).cel = {
         id: "int32.gte",
@@ -735,31 +739,31 @@ message Int32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated int32 in = 6 [(priv.field).cel = {
     id: "int32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated int32 not_in = 7 [(priv.field).cel = {
     id: "int32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -769,30 +773,30 @@ message Int32Rules {
 // Int64Rules describes the constraints applied to `int64` values. These
 // rules may also be applied to the `google.protobuf.Int64Value` Well-Known-Type.
 message Int64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyInt64 {
+  //   // value must equal 42
   //   int64 value = 1 [(buf.validate.field).int64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional int64 const = 1 [(priv.field).cel = {
     id: "int64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyInt64 {
+    //   // value must be less than 10
     //   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     int64 lt = 2 [(priv.field).cel = {
       id: "int64.lt",
       expression:
@@ -800,16 +804,16 @@ message Int64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyInt64 {
+    //   // value must be less than or equal to 10
     //   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     int64 lte = 3 [(priv.field).cel = {
       id: "int64.lte",
       expression:
@@ -818,24 +822,24 @@ message Int64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be greater than 5 [int64.gt]
-    //  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+    // ```proto
+    // message MyInt64 {
+    //   // value must be greater than 5 [int64.gt]
+    //   int64 value = 1 [(buf.validate.field).int64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [int64.gt_lt]
-    //  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [int64.gt_lt]
+    //   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-    //  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+    //   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     int64 gt = 4 [
       (priv.field).cel = {
         id: "int64.gt",
@@ -869,24 +873,24 @@ message Int64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be greater than or equal to 5 [int64.gte]
-    //  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+    // ```proto
+    // message MyInt64 {
+    //   // value must be greater than or equal to 5 [int64.gte]
+    //   int64 value = 1 [(buf.validate.field).int64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-    //  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+    //   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-    //  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+    //   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     int64 gte = 5 [
       (priv.field).cel = {
         id: "int64.gte",
@@ -921,31 +925,31 @@ message Int64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated int64 in = 6 [(priv.field).cel = {
     id: "int64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated int64 not_in = 7 [(priv.field).cel = {
     id: "int64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -955,30 +959,30 @@ message Int64Rules {
 // UInt32Rules describes the constraints applied to `uint32` values. These
 // rules may also be applied to the `google.protobuf.UInt32Value` Well-Known-Type.
 message UInt32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyUInt32 {
+  //   // value must equal 42
   //   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional uint32 const = 1 [(priv.field).cel = {
     id: "uint32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be less than 10
     //   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     uint32 lt = 2 [(priv.field).cel = {
       id: "uint32.lt",
       expression:
@@ -986,16 +990,16 @@ message UInt32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be less than or equal to 10
     //   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     uint32 lte = 3 [(priv.field).cel = {
       id: "uint32.lte",
       expression:
@@ -1004,24 +1008,24 @@ message UInt32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be greater than 5 [uint32.gt]
-    //  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be greater than 5 [uint32.gt]
+    //   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-    //  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+    //   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-    //  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+    //   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     uint32 gt = 4 [
       (priv.field).cel = {
         id: "uint32.gt",
@@ -1055,24 +1059,24 @@ message UInt32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be greater than or equal to 5 [uint32.gte]
-    //  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be greater than or equal to 5 [uint32.gte]
+    //   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-    //  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+    //   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-    //  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+    //   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     uint32 gte = 5 [
       (priv.field).cel = {
         id: "uint32.gte",
@@ -1107,31 +1111,31 @@ message UInt32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint32 in = 6 [(priv.field).cel = {
     id: "uint32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint32 not_in = 7 [(priv.field).cel = {
     id: "uint32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1141,30 +1145,30 @@ message UInt32Rules {
 // UInt64Rules describes the constraints applied to `uint64` values. These
 // rules may also be applied to the `google.protobuf.UInt64Value` Well-Known-Type.
 message UInt64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyUInt64 {
+  //   // value must equal 42
   //   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 const = 1 [(priv.field).cel = {
     id: "uint64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be less than 10
     //   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     uint64 lt = 2 [(priv.field).cel = {
       id: "uint64.lt",
       expression:
@@ -1172,16 +1176,16 @@ message UInt64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be less than or equal to 10
     //   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     uint64 lte = 3 [(priv.field).cel = {
       id: "uint64.lte",
       expression:
@@ -1190,24 +1194,24 @@ message UInt64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be greater than 5 [uint64.gt]
-    //  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be greater than 5 [uint64.gt]
+    //   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-    //  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+    //   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-    //  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+    //   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     uint64 gt = 4 [
       (priv.field).cel = {
         id: "uint64.gt",
@@ -1241,24 +1245,24 @@ message UInt64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be greater than or equal to 5 [uint64.gte]
-    //  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be greater than or equal to 5 [uint64.gte]
+    //   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-    //  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+    //   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-    //  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+    //   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     uint64 gte = 5 [
       (priv.field).cel = {
         id: "uint64.gte",
@@ -1292,31 +1296,31 @@ message UInt64Rules {
       }
     ];
   }
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint64 in = 6 [(priv.field).cel = {
     id: "uint64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint64 not_in = 7 [(priv.field).cel = {
     id: "uint64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1325,30 +1329,30 @@ message UInt64Rules {
 
 // SInt32Rules describes the constraints applied to `sint32` values.
 message SInt32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MySInt32 {
+  //   // value must equal 42
   //   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sint32 const = 1 [(priv.field).cel = {
     id: "sint32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field
+    // `lt` requires the field value to be less than the specified value (field
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySInt32 {
+    //   // value must be less than 10
     //   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sint32 lt = 2 [(priv.field).cel = {
       id: "sint32.lt",
       expression:
@@ -1356,16 +1360,16 @@ message SInt32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySInt32 {
+    //   // value must be less than or equal to 10
     //   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sint32 lte = 3 [(priv.field).cel = {
       id: "sint32.lte",
       expression:
@@ -1374,24 +1378,24 @@ message SInt32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be greater than 5 [sint32.gt]
-    //  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+    // ```proto
+    // message MySInt32 {
+    //   // value must be greater than 5 [sint32.gt]
+    //   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-    //  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+    //   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-    //  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+    //   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sint32 gt = 4 [
       (priv.field).cel = {
         id: "sint32.gt",
@@ -1425,14 +1429,14 @@ message SInt32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
+    // ```proto
+    // message MySInt32 {
     //  // value must be greater than or equal to 5 [sint32.gte]
     //  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
     //
@@ -1441,8 +1445,8 @@ message SInt32Rules {
     //
     //  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
     //  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    // }
+    // ```
     sint32 gte = 5 [
       (priv.field).cel = {
         id: "sint32.gte",
@@ -1477,31 +1481,31 @@ message SInt32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint32 in = 6 [(priv.field).cel = {
     id: "sint32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint32 not_in = 7 [(priv.field).cel = {
     id: "sint32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1510,30 +1514,30 @@ message SInt32Rules {
 
 // SInt64Rules describes the constraints applied to `sint64` values.
 message SInt64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MySInt64 {
+  //   // value must equal 42
   //   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sint64 const = 1 [(priv.field).cel = {
     id: "sint64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field
+    // `lt` requires the field value to be less than the specified value (field
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySInt64 {
+    //   // value must be less than 10
     //   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sint64 lt = 2 [(priv.field).cel = {
       id: "sint64.lt",
       expression:
@@ -1541,16 +1545,16 @@ message SInt64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySInt64 {
+    //   // value must be less than or equal to 10
     //   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sint64 lte = 3 [(priv.field).cel = {
       id: "sint64.lte",
       expression:
@@ -1559,24 +1563,24 @@ message SInt64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be greater than 5 [sint64.gt]
-    //  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+    // ```proto
+    // message MySInt64 {
+    //   // value must be greater than 5 [sint64.gt]
+    //   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-    //  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+    //   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-    //  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+    //   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sint64 gt = 4 [
       (priv.field).cel = {
         id: "sint64.gt",
@@ -1610,24 +1614,24 @@ message SInt64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be greater than or equal to 5 [sint64.gte]
-    //  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+    // ```proto
+    // message MySInt64 {
+    //   // value must be greater than or equal to 5 [sint64.gte]
+    //   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-    //  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+    //   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-    //  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+    //   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sint64 gte = 5 [
       (priv.field).cel = {
         id: "sint64.gte",
@@ -1662,31 +1666,31 @@ message SInt64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint64 in = 6 [(priv.field).cel = {
     id: "sint64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint64 not_in = 7 [(priv.field).cel = {
     id: "sint64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1695,30 +1699,30 @@ message SInt64Rules {
 
 // Fixed32Rules describes the constraints applied to `fixed32` values.
 message Fixed32Rules {
-  //`const` requires the field value to exactly match the specified value.
+  // `const` requires the field value to exactly match the specified value.
   // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyFixed32 {
+  //   // value must equal 42
   //   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional fixed32 const = 1 [(priv.field).cel = {
     id: "fixed32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be less than 10
     //   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed32 lt = 2 [(priv.field).cel = {
       id: "fixed32.lt",
       expression:
@@ -1726,16 +1730,16 @@ message Fixed32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be less than or equal to 10
     //   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed32 lte = 3 [(priv.field).cel = {
       id: "fixed32.lte",
       expression:
@@ -1744,24 +1748,24 @@ message Fixed32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be greater than 5 [fixed32.gt]
-    //  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be greater than 5 [fixed32.gt]
+    //   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-    //  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+    //   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-    //  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+    //   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     fixed32 gt = 4 [
       (priv.field).cel = {
         id: "fixed32.gt",
@@ -1795,24 +1799,24 @@ message Fixed32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be greater than or equal to 5 [fixed32.gte]
-    //  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be greater than or equal to 5 [fixed32.gte]
+    //   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-    //  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+    //   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-    //  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+    //   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     fixed32 gte = 5 [
       (priv.field).cel = {
         id: "fixed32.gte",
@@ -1847,31 +1851,31 @@ message Fixed32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed32 in = 6 [(priv.field).cel = {
     id: "fixed32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed32 not_in = 7 [(priv.field).cel = {
     id: "fixed32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1880,30 +1884,30 @@ message Fixed32Rules {
 
 // Fixed64Rules describes the constraints applied to `fixed64` values.
 message Fixed64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyFixed64 {
+  //   // value must equal 42
   //   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional fixed64 const = 1 [(priv.field).cel = {
     id: "fixed64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be less than 10
     //   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed64 lt = 2 [(priv.field).cel = {
       id: "fixed64.lt",
       expression:
@@ -1911,16 +1915,16 @@ message Fixed64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be less than or equal to 10
     //   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed64 lte = 3 [(priv.field).cel = {
       id: "fixed64.lte",
       expression:
@@ -1929,24 +1933,24 @@ message Fixed64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be greater than 5 [fixed64.gt]
-    //  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be greater than 5 [fixed64.gt]
+    //   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-    //  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+    //   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-    //  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+    //   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     fixed64 gt = 4 [
       (priv.field).cel = {
         id: "fixed64.gt",
@@ -1980,24 +1984,24 @@ message Fixed64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be greater than or equal to 5 [fixed64.gte]
-    //  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be greater than or equal to 5 [fixed64.gte]
+    //   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-    //  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+    //   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-    //  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+    //   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     fixed64 gte = 5 [
       (priv.field).cel = {
         id: "fixed64.gte",
@@ -2032,31 +2036,31 @@ message Fixed64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed64 in = 6 [(priv.field).cel = {
     id: "fixed64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed64 not_in = 7 [(priv.field).cel = {
     id: "fixed64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2065,30 +2069,30 @@ message Fixed64Rules {
 
 // SFixed32Rules describes the constraints applied to `fixed32` values.
 message SFixed32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must equal 42
+  // ```proto
+  // message MySFixed32 {
+  //   // value must equal 42
   //   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sfixed32 const = 1 [(priv.field).cel = {
     id: "sfixed32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be less than 10
     //   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed32 lt = 2 [(priv.field).cel = {
       id: "sfixed32.lt",
       expression:
@@ -2096,16 +2100,16 @@ message SFixed32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be less than or equal to 10
     //   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed32 lte = 3 [(priv.field).cel = {
       id: "sfixed32.lte",
       expression:
@@ -2114,24 +2118,24 @@ message SFixed32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be greater than 5 [sfixed32.gt]
-    //  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be greater than 5 [sfixed32.gt]
+    //   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-    //  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+    //   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-    //  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+    //   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sfixed32 gt = 4 [
       (priv.field).cel = {
         id: "sfixed32.gt",
@@ -2165,24 +2169,24 @@ message SFixed32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be greater than or equal to 5 [sfixed32.gte]
-    //  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be greater than or equal to 5 [sfixed32.gte]
+    //   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-    //  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+    //   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-    //  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+    //   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sfixed32 gte = 5 [
       (priv.field).cel = {
         id: "sfixed32.gte",
@@ -2217,31 +2221,31 @@ message SFixed32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed32 in = 6 [(priv.field).cel = {
     id: "sfixed32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed32 not_in = 7 [(priv.field).cel = {
     id: "sfixed32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2250,30 +2254,30 @@ message SFixed32Rules {
 
 // SFixed64Rules describes the constraints applied to `fixed64` values.
 message SFixed64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must equal 42
+  // ```proto
+  // message MySFixed64 {
+  //   // value must equal 42
   //   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sfixed64 const = 1 [(priv.field).cel = {
     id: "sfixed64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be less than 10
     //   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed64 lt = 2 [(priv.field).cel = {
       id: "sfixed64.lt",
       expression:
@@ -2281,16 +2285,16 @@ message SFixed64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be less than or equal to 10
     //   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed64 lte = 3 [(priv.field).cel = {
       id: "sfixed64.lte",
       expression:
@@ -2299,24 +2303,24 @@ message SFixed64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be greater than 5 [sfixed64.gt]
-    //  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be greater than 5 [sfixed64.gt]
+    //   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-    //  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+    //   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-    //  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+    //   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sfixed64 gt = 4 [
       (priv.field).cel = {
         id: "sfixed64.gt",
@@ -2350,24 +2354,24 @@ message SFixed64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be greater than or equal to 5 [sfixed64.gte]
-    //  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be greater than or equal to 5 [sfixed64.gte]
+    //   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-    //  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+    //   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-    //  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+    //   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sfixed64 gte = 5 [
       (priv.field).cel = {
         id: "sfixed64.gte",
@@ -2402,31 +2406,31 @@ message SFixed64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed64 in = 6 [(priv.field).cel = {
     id: "sfixed64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed64 not_in = 7 [(priv.field).cel = {
     id: "sfixed64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2436,15 +2440,15 @@ message SFixed64Rules {
 // BoolRules describes the constraints applied to `bool` values. These rules
 // may also be applied to the `google.protobuf.BoolValue` Well-Known-Type.
 message BoolRules {
-  //`const` requires the field value to exactly match the specified boolean value.
-  //If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified boolean value.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBool {
-  //  // value must equal true
+  // ```proto
+  // message MyBool {
+  //   // value must equal true
   //   bool value = 1 [(buf.validate.field).bool.const = true];
-  //}
-  //```
+  // }
+  // ```
   optional bool const = 1 [(priv.field).cel = {
     id: "bool.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -2454,215 +2458,215 @@ message BoolRules {
 // StringRules describes the constraints applied to `string` values These
 // rules may also be applied to the `google.protobuf.StringValue` Well-Known-Type.
 message StringRules {
-  //`const` requires the field value to exactly match the specified value. If
-  //the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified value. If
+  // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyString {
-  //  // value must equal `hello`
+  // ```proto
+  // message MyString {
+  //   // value must equal `hello`
   //   string value = 1 [(buf.validate.field).string.const = "hello"];
-  //}
-  //```
+  // }
+  // ```
   optional string const = 1 [(priv.field).cel = {
     id: "string.const",
     expression: "this != rules.const ? 'value must equal `%s`'.format([rules.const]) : ''"
   }];
 
-  //`len` dictates that the field value must have the specified
-  //number of characters (Unicode code points), which may differ from the number
-  //of bytes in the string. If the field value does not meet the specified
-  //length, an error message will be generated.
+  // `len` dictates that the field value must have the specified
+  // number of characters (Unicode code points), which may differ from the number
+  // of bytes in the string. If the field value does not meet the specified
+  // length, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be 5 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be 5 characters
   //   string value = 1 [(buf.validate.field).string.len = 5];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 len = 19 [(priv.field).cel = {
     id: "string.len",
     expression: "uint(this.size()) != rules.len ? 'value length must be %s characters'.format([rules.len]) : ''"
   }];
 
-  //`min_len` specifies that the field value must have at least the specified
-  //number of characters (Unicode code points), which may differ from the number
-  //of bytes in the string. If the field value contains fewer characters, an error
-  //message will be generated.
+  // `min_len` specifies that the field value must have at least the specified
+  // number of characters (Unicode code points), which may differ from the number
+  // of bytes in the string. If the field value contains fewer characters, an error
+  // message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at least 3 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be at least 3 characters
   //   string value = 1 [(buf.validate.field).string.min_len = 3];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 min_len = 2 [(priv.field).cel = {
     id: "string.min_len",
     expression: "uint(this.size()) < rules.min_len ? 'value length must be at least %s characters'.format([rules.min_len]) : ''"
   }];
 
-  //`max_len` specifies that the field value must have no more than the specified
-  //number of characters (Unicode code points), which may differ from the
-  //number of bytes in the string. If the field value contains more characters,
-  //an error message will be generated.
+  // `max_len` specifies that the field value must have no more than the specified
+  // number of characters (Unicode code points), which may differ from the
+  // number of bytes in the string. If the field value contains more characters,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at most 10 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be at most 10 characters
   //   string value = 1 [(buf.validate.field).string.max_len = 10];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 max_len = 3 [(priv.field).cel = {
     id: "string.max_len",
     expression: "uint(this.size()) > rules.max_len ? 'value length must be at most %s characters'.format([rules.max_len]) : ''"
   }];
 
-  //`len_bytes` dictates that the field value must have the specified number of
-  //bytes. If the field value does not match the specified length in bytes,
-  //an error message will be generated.
+  // `len_bytes` dictates that the field value must have the specified number of
+  // bytes. If the field value does not match the specified length in bytes,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be 6 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be 6 bytes
   //   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 len_bytes = 20 [(priv.field).cel = {
     id: "string.len_bytes",
     expression: "uint(bytes(this).size()) != rules.len_bytes ? 'value length must be %s bytes'.format([rules.len_bytes]) : ''"
   }];
 
-  //`min_bytes` specifies that the field value must have at least the specified
-  //number of bytes. If the field value contains fewer bytes, an error message
-  //will be generated.
+  // `min_bytes` specifies that the field value must have at least the specified
+  // number of bytes. If the field value contains fewer bytes, an error message
+  // will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at least 4 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be at least 4 bytes
   //   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-  //}
+  // }
   //
-  //```
+  // ```
   optional uint64 min_bytes = 4 [(priv.field).cel = {
     id: "string.min_bytes",
     expression: "uint(bytes(this).size()) < rules.min_bytes ? 'value length must be at least %s bytes'.format([rules.min_bytes]) : ''"
   }];
 
-  //`max_bytes` specifies that the field value must have no more than the
+  // `max_bytes` specifies that the field value must have no more than the
   //specified number of bytes. If the field value contains more bytes, an
-  //error message will be generated.
+  // error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at most 8 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be at most 8 bytes
   //   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 max_bytes = 5 [(priv.field).cel = {
     id: "string.max_bytes",
     expression: "uint(bytes(this).size()) > rules.max_bytes ? 'value length must be at most %s bytes'.format([rules.max_bytes]) : ''",
   }];
 
-  //`pattern` specifies that the field value must match the specified
-  //regular expression (RE2 syntax), with the expression provided without any
-  //delimiters. If the field value doesn't match the regular expression, an
-  //error message will be generated.
+  // `pattern` specifies that the field value must match the specified
+  // regular expression (RE2 syntax), with the expression provided without any
+  // delimiters. If the field value doesn't match the regular expression, an
+  // error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not match regex pattern `^[a-zA-Z]//$`
+  // ```proto
+  // message MyString {
+  //   // value does not match regex pattern `^[a-zA-Z]//$`
   //   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-  //}
-  //```
+  // }
+  // ```
   optional string pattern = 6 [(priv.field).cel = {
     id: "string.pattern",
     expression: "!this.matches(rules.pattern) ? 'value does not match regex pattern `%s`'.format([rules.pattern]) : ''"
   }];
 
-  //`prefix` specifies that the field value must have the
+  // `prefix` specifies that the field value must have the
   //specified substring at the beginning of the string. If the field value
-  //doesn't start with the specified prefix, an error message will be
-  //generated.
+  // doesn't start with the specified prefix, an error message will be
+  // generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not have prefix `pre`
+  // ```proto
+  // message MyString {
+  //   // value does not have prefix `pre`
   //   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-  //}
-  //```
+  // }
+  // ```
   optional string prefix = 7 [(priv.field).cel = {
     id: "string.prefix",
     expression: "!this.startsWith(rules.prefix) ? 'value does not have prefix `%s`'.format([rules.prefix]) : ''"
   }];
 
-  //`suffix` specifies that the field value must have the
+  // `suffix` specifies that the field value must have the
   //specified substring at the end of the string. If the field value doesn't
-  //end with the specified suffix, an error message will be generated.
+  // end with the specified suffix, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not have suffix `post`
+  // ```proto
+  // message MyString {
+  //   // value does not have suffix `post`
   //   string value = 1 [(buf.validate.field).string.suffix = "post"];
-  //}
-  //```
+  // }
+  // ```
   optional string suffix = 8 [(priv.field).cel = {
     id: "string.suffix",
     expression: "!this.endsWith(rules.suffix) ? 'value does not have suffix `%s`'.format([rules.suffix]) : ''"
   }];
 
-  //`contains` specifies that the field value must have the
+  // `contains` specifies that the field value must have the
   //specified substring anywhere in the string. If the field value doesn't
-  //contain the specified substring, an error message will be generated.
+  // contain the specified substring, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not contain substring `inside`.
+  // ```proto
+  // message MyString {
+  //   // value does not contain substring `inside`.
   //   string value = 1 [(buf.validate.field).string.contains = "inside"];
-  //}
-  //```
+  // }
+  // ```
   optional string contains = 9 [(priv.field).cel = {
     id: "string.contains",
     expression: "!this.contains(rules.contains) ? 'value does not contain substring `%s`'.format([rules.contains]) : ''"
   }];
 
-  //`not_contains` specifies that the field value must not have the
+  // `not_contains` specifies that the field value must not have the
   //specified substring anywhere in the string. If the field value contains
-  //the specified substring, an error message will be generated.
+  // the specified substring, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value contains substring `inside`.
+  // ```proto
+  // message MyString {
+  //   // value contains substring `inside`.
   //   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-  //}
-  //```
+  // }
+  // ```
   optional string not_contains = 23 [(priv.field).cel = {
     id: "string.not_contains",
     expression: "this.contains(rules.not_contains) ? 'value contains substring `%s`'.format([rules.not_contains]) : ''"
   }];
 
-  //`in` specifies that the field value must be equal to one of the specified
-  //values. If the field value isn't one of the specified values, an error
-  //message will be generated.
+  // `in` specifies that the field value must be equal to one of the specified
+  // values. If the field value isn't one of the specified values, an error
+  // message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value must be in list ["apple", "banana"]
-  //  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-  //}
-  //```
+  // ```proto
+  // message MyString {
+  //   // value must be in list ["apple", "banana"]
+  //   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+  // }
+  // ```
   repeated string in = 10 [(priv.field).cel = {
     id: "string.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''"
   }];
 
-  //`not_in` specifies that the field value cannot be equal to any
-  //of the specified values. If the field value is one of the specified values,
-  //an error message will be generated.
-  //```proto
-  //message MyString {
-  //  // value must not be in list ["orange", "grape"]
-  //  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-  //}
-  //```
+  // `not_in` specifies that the field value cannot be equal to any
+  // of the specified values. If the field value is one of the specified values,
+  // an error message will be generated.
+  // ```proto
+  // message MyString {
+  //   // value must not be in list ["orange", "grape"]
+  //   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+  // }
+  // ```
   repeated string not_in = 11 [(priv.field).cel = {
     id: "string.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''"
@@ -2671,173 +2675,173 @@ message StringRules {
   // `WellKnown` rules provide advanced constraints against common string
   // patterns
   oneof well_known {
-    //`email` specifies that the field value must be a valid email address
-    //(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-    //If the field value isn't a valid email address, an error message will be generated.
+    // `email` specifies that the field value must be a valid email address
+    // (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+    // If the field value isn't a valid email address, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid email address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid email address
     //   string value = 1 [(buf.validate.field).string.email = true];
-    //}
-    //```
+    // }
+    // ```
     bool email = 12 [(priv.field).cel = {
       id: "string.email",
       message: "value must be a valid email address",
       expression: "this.isEmail()"
     }];
 
-    //`hostname` specifies that the field value must be a valid
-    //hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-    //internationalized domain names (IDNs). If the field value isn't a
-    //valid hostname, an error message will be generated.
+    // `hostname` specifies that the field value must be a valid
+    // hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+    // internationalized domain names (IDNs). If the field value isn't a
+    // valid hostname, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid hostname
+    // ```proto
+    // message MyString {
+    //   // value must be a valid hostname
     //   string value = 1 [(buf.validate.field).string.hostname = true];
-    //}
-    //```
+    // }
+    // ```
     bool hostname = 13 [(priv.field).cel = {
       id: "string.hostname",
       message: "value must be a valid hostname",
       expression: "this.isHostname()",
     }];
 
-    //`ip` specifies that the field value must be a valid IP
-    //(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-    //If the field value isn't a valid IP address, an error message will be
-    //generated.
+    // `ip` specifies that the field value must be a valid IP
+    // (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+    // If the field value isn't a valid IP address, an error message will be
+    // generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IP address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IP address
     //   string value = 1 [(buf.validate.field).string.ip = true];
-    //}
-    //```
+    // }
+    // ```
     bool ip = 14 [(priv.field).cel = {
       id: "string.ip",
       message: "value must be a valid IP address",
       expression: "this.isIp()",
     }];
 
-    //`ipv4` specifies that the field value must be a valid IPv4
-    //address. If the field value isn't a valid IPv4 address, an error message
-    //will be generated.
+    // `ipv4` specifies that the field value must be a valid IPv4
+    // address. If the field value isn't a valid IPv4 address, an error message
+    // will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IPv4 address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IPv4 address
     //   string value = 1 [(buf.validate.field).string.ipv4 = true];
-    //}
-    //```
+    // }
+    // ```
     bool ipv4 = 15 [(priv.field).cel = {
       id: "string.ipv4",
       message: "value must be a valid IPv4 address",
       expression: "this.isIp(4)"
     }];
 
-    //`ipv6` specifies that the field value must be a valid
-    //IPv6 address, without surrounding square brackets. If the field value is
-    //not a valid IPv6 address, an error message will be generated.
+    // `ipv6` specifies that the field value must be a valid
+    // IPv6 address, without surrounding square brackets. If the field value is
+    // not a valid IPv6 address, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IPv6 address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IPv6 address
     //   string value = 1 [(buf.validate.field).string.ipv6 = true];
-    //}
-    //```
+    // }
+    // ```
     bool ipv6 = 16 [(priv.field).cel = {
       id: "string.ipv6",
       message: "value must be a valid IPv6 address",
       expression: "this.isIp(6)",
     }];
 
-    //`uri` specifies that the field value must be a valid,
-    //absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-    //absolute URI, an error message will be generated.
+    // `uri` specifies that the field value must be a valid,
+    // absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+    // absolute URI, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid URI
+    // ```proto
+    // message MyString {
+    //   // value must be a valid URI
     //   string value = 1 [(buf.validate.field).string.uri = true];
-    //}
-    //```
+    // }
+    // ```
     bool uri = 17 [(priv.field).cel = {
       id: "string.uri",
       message: "value must be a valid URI",
       expression: "this.isUri()",
     }];
 
-    //`uri_ref` specifies that the field value must be a valid URI
-    //as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-    //field value isn't a valid URI, an error message will be generated.
+    // `uri_ref` specifies that the field value must be a valid URI
+    // as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+    // field value isn't a valid URI, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid URI
+    // ```proto
+    // message MyString {
+    //   // value must be a valid URI
     //   string value = 1 [(buf.validate.field).string.uri_ref = true];
-    //}
-    //```
+    // }
+    // ```
     bool uri_ref = 18 [(priv.field).cel = {
       id: "string.uri_ref",
       message: "value must be a valid URI",
       expression: "this.isUriRef()",
     }];
 
-    //`address` specifies that the field value must be either a valid hostname
-    //as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-    //(which doesn't support internationalized domain names or IDNs) or a valid
-    //IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-    //message will be generated.
+    // `address` specifies that the field value must be either a valid hostname
+    // as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+    // (which doesn't support internationalized domain names or IDNs) or a valid
+    // IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+    // message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid hostname, or ip address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid hostname, or ip address
     //   string value = 1 [(buf.validate.field).string.address = true];
-    //}
-    //```
+    // }
+    // ```
     bool address = 21 [(priv.field).cel = {
       id: "string.address",
       message: "value must be a valid hostname, or ip address",
       expression: "this.isHostname() || this.isIp()",
     }];
 
-    //`uuid` specifies that the field value must be a valid UUID as defined by
-    //[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-    //field value isn't a valid UUID, an error message will be generated.
+    // `uuid` specifies that the field value must be a valid UUID as defined by
+    // [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+    // field value isn't a valid UUID, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid UUID
+    // ```proto
+    // message MyString {
+    //   // value must be a valid UUID
     //   string value = 1 [(buf.validate.field).string.uuid = true];
-    //}
-    //```
+    // }
+    // ```
     bool uuid = 22 [(priv.field).cel = {
       id: "string.uuid",
       expression: "!this.matches('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') ? 'value must be a valid UUID' : ''"
     }];
 
-    //`well_known_regex` specifies a common well-known pattern
-    //defined as a regex. If the field value doesn't match the well-known
-    //regex, an error message will be generated.
+    // `well_known_regex` specifies a common well-known pattern
+    // defined as a regex. If the field value doesn't match the well-known
+    // regex, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid HTTP header value
+    // ```proto
+    // message MyString {
+    //   // value must be a valid HTTP header value
     //   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-    //}
-    //```
+    // }
+    // ```
     //
-    //#### KnownRegex
+    // #### KnownRegex
     //
-    //`well_known_regex` contains some well-known patterns.
+    // `well_known_regex` contains some well-known patterns.
     //
-    //| Name                          | Number | Description                               |
-    //|-------------------------------|--------|-------------------------------------------|
-    //| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-    //| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-    //| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+    // | Name                          | Number | Description                               |
+    // |-------------------------------|--------|-------------------------------------------|
+    // | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+    // | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+    // | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
     KnownRegex well_known_regex = 24 [
       (priv.field).cel = {
         id: "string.well_known_regex.header_name"
@@ -2856,18 +2860,18 @@ message StringRules {
     ];
   }
 
-  //This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-  //enable strict header validation. By default, this is true, and HTTP header
-  //validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-  //validations that only disallow `\r\n\0` characters, which can be used to
-  //bypass header matching rules.
+  // This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+  // enable strict header validation. By default, this is true, and HTTP header
+  // validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+  // validations that only disallow `\r\n\0` characters, which can be used to
+  // bypass header matching rules.
   //
-  //```proto
-  //message MyString {
+  // ```proto
+  // message MyString {
   //   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
   //   string value = 1 [(buf.validate.field).string.strict = false];
-  //}
-  //```
+  // }
+  // ```
   optional bool strict = 25;
 }
 
@@ -2885,152 +2889,152 @@ enum KnownRegex {
 // BytesRules describe the constraints applied to `bytes` values. These rules
 // may also be applied to the `google.protobuf.BytesValue` Well-Known-Type.
 message BytesRules {
-  //`const` requires the field value to exactly match the specified bytes
-  //value. If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified bytes
+  // value. If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //  // value must be "\x01\x02\x03\x04"
+  // ```proto
+  // message MyBytes {
+  //   // value must be "\x01\x02\x03\x04"
   //   bytes value = 1 [(buf.validate.field).bytes.const = "\x01\x02\x03\x04"];
-  //}
-  //```
+  // }
+  // ```
   optional bytes const = 1 [(priv.field).cel = {
     id: "bytes.const",
     expression: "this != rules.const ? 'value must be %x'.format([rules.const]) : ''"
   }];
 
-  //`len` requires the field value to have the specified length in bytes.
-  //If the field value doesn't match, an error message is generated.
+  // `len` requires the field value to have the specified length in bytes.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //      // value length must be 4 bytes.
-  //      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value length must be 4 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+  // }
+  // ```
   optional uint64 len = 13 [(priv.field).cel = {
     id: "bytes.len",
     expression: "uint(this.size()) != rules.len ? 'value length must be %s bytes'.format([rules.len]) : ''"
   }];
 
-  //`min_len` requires the field value to have at least the specified minimum
-  //length in bytes.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `min_len` requires the field value to have at least the specified minimum
+  // length in bytes.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value length must be at least 2 bytes.
-  // optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value length must be at least 2 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+  // }
+  // ```
   optional uint64 min_len = 2 [(priv.field).cel = {
     id: "bytes.min_len",
     expression: "uint(this.size()) < rules.min_len ? 'value length must be at least %s bytes'.format([rules.min_len]) : ''"
   }];
 
-  //`max_len` requires the field value to have at most the specified maximum
-  //length in bytes.
-  //If the field value exceeds the requirement, an error message is generated.
+  // `max_len` requires the field value to have at most the specified maximum
+  // length in bytes.
+  // If the field value exceeds the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must be at most 6 bytes.
-  // optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must be at most 6 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+  // }
+  // ```
   optional uint64 max_len = 3 [(priv.field).cel = {
     id: "bytes.max_len",
     expression: "uint(this.size()) > rules.max_len ? 'value must be at most %s bytes'.format([rules.max_len]) : ''"
   }];
 
-  //`pattern` requires the field value to match the specified regular
-  //expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-  //The value of the field must be valid UTF-8 or validation will fail with a
-  //runtime error.
-  //If the field value doesn't match the pattern, an error message is generated.
+  // `pattern` requires the field value to match the specified regular
+  // expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+  // The value of the field must be valid UTF-8 or validation will fail with a
+  // runtime error.
+  // If the field value doesn't match the pattern, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must match regex pattern "^[a-zA-Z0-9]+$".
-  // optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must match regex pattern "^[a-zA-Z0-9]+$".
+  //   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+  // }
+  // ```
   optional string pattern = 4 [(priv.field).cel = {
     id: "bytes.pattern",
     expression: "!string(this).matches(rules.pattern) ? 'value must match regex pattern `%s`'.format([rules.pattern]) : ''"
   }];
 
-  //`prefix` requires the field value to have the specified bytes at the
-  //beginning of the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `prefix` requires the field value to have the specified bytes at the
+  // beginning of the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //// value does not have prefix \x01\x02
-  //optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value does not have prefix \x01\x02
+  //   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
+  // }
+  // ```
   optional bytes prefix = 5 [(priv.field).cel = {
     id: "bytes.prefix",
     expression: "!this.startsWith(rules.prefix) ? 'value does not have prefix %x'.format([rules.prefix]) : ''"
   }];
 
-  //`suffix` requires the field value to have the specified bytes at the end
-  //of the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `suffix` requires the field value to have the specified bytes at the end
+  // of the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value does not have suffix \x03\x04
-  // optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value does not have suffix \x03\x04
+  //   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
+  // }
+  // ```
   optional bytes suffix = 6 [(priv.field).cel = {
     id: "bytes.suffix",
     expression: "!this.endsWith(rules.suffix) ? 'value does not have suffix %x'.format([rules.suffix]) : ''"
   }];
 
-  //`contains` requires the field value to have the specified bytes anywhere in
-  //the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `contains` requires the field value to have the specified bytes anywhere in
+  // the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```protobuf
-  //message MyBytes {
-  // // value does not contain \x02\x03
-  // optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
-  //}
-  //```
+  // ```protobuf
+  // message MyBytes {
+  //   // value does not contain \x02\x03
+  //   optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
+  // }
+  // ```
   optional bytes contains = 7 [(priv.field).cel = {
     id: "bytes.contains",
     expression: "!this.contains(rules.contains) ? 'value does not contain %x'.format([rules.contains]) : ''"
   }];
 
-  //`in` requires the field value to be equal to one of the specified
-  //values. If the field value doesn't match any of the specified values, an
-  //error message is generated.
+  // `in` requires the field value to be equal to one of the specified
+  // values. If the field value doesn't match any of the specified values, an
+  // error message is generated.
   //
-  //```protobuf
-  //message MyBytes {
-  // // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  // optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-  //}
-  //```
+  // ```protobuf
+  // message MyBytes {
+  //   // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
+  //   optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  // }
+  // ```
   repeated bytes in = 8 [(priv.field).cel = {
     id: "bytes.in",
     expression: "dyn(rules)['in'].size() > 0 && !(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''"
   }];
 
-  //`not_in` requires the field value to be not equal to any of the specified
-  //values.
-  //If the field value matches any of the specified values, an error message is
-  //generated.
+  // `not_in` requires the field value to be not equal to any of the specified
+  // values.
+  // If the field value matches any of the specified values, an error message is
+  // generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  // optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
+  //   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  // }
+  // ```
   repeated bytes not_in = 9 [(priv.field).cel = {
     id: "bytes.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''"
@@ -3039,42 +3043,42 @@ message BytesRules {
   // WellKnown rules provide advanced constraints against common byte
   // patterns
   oneof well_known {
-    //`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
+    // `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
     //
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IP address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-    //}
-    //```
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IP address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+    // }
+    // ```
     bool ip = 10 [(priv.field).cel = {
       id: "bytes.ip",
       expression: "this.size() != 4 && this.size() != 16 ? 'value must be a valid IP address' : ''"
     }];
 
-    //`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
+    // `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
     //
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IPv4 address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-    //}
-    //```
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IPv4 address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+    // }
+    // ```
     bool ipv4 = 11 [(priv.field).cel = {
       id: "bytes.ipv4",
       expression: "this.size() != 4 ? 'value must be a valid IPv4 address' : ''"
     }];
 
-    //`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IPv6 address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-    //}
-    //```
+    // `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IPv6 address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+    // }
+    // ```
     bool ipv6 = 12 [(priv.field).cel = {
       id: "bytes.ipv6",
       expression: "this.size() != 16 ? 'value must be a valid IPv6 address' : ''"
@@ -3084,80 +3088,80 @@ message BytesRules {
 
 // EnumRules describe the constraints applied to `enum` values.
 message EnumRules {
-  //`const` requires the field value to exactly match the specified enum value.
-  //If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified enum value.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be exactly MY_ENUM_VALUE1.
+  // message MyMessage {
+  //   // The field `value` must be exactly MY_ENUM_VALUE1.
   //   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-  //}
-  //```
+  // }
+  // ```
   optional int32 const = 1 [(priv.field).cel = {
     id: "enum.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
 
-  //`defined_only` requires the field value to be one of the defined values for
+  // `defined_only` requires the field value to be one of the defined values for
   // this enum, failing on any undefined value.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be a defined value of MyEnum.
+  // message MyMessage {
+  //   // The field `value` must be a defined value of MyEnum.
   //   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-  //}
-  //```
+  // }
+  // ```
   optional bool defined_only = 2;
 
-  //`in` requires the field value to be equal to one of the
+  // `in` requires the field value to be equal to one of the
   //specified enum values. If the field value doesn't match any of the
   //specified values, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be equal to one of the specified values.
+  // message MyMessage {
+  //   // The field `value` must be equal to one of the specified values.
   //   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-  //}
-  //```
+  // }
+  // ```
   repeated int32 in = 3 [(priv.field).cel = {
     id: "enum.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to be not equal to any of the
+  // `not_in` requires the field value to be not equal to any of the
   //specified enum values. If the field value matches one of the specified
-  //values, an error message is generated.
+  // values, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must not be equal to any of the specified values.
+  // message MyMessage {
+  //   // The field `value` must not be equal to any of the specified values.
   //   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-  //}
-  //```
+  // }
+  // ```
   repeated int32 not_in = 4 [(priv.field).cel = {
     id: "enum.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -3166,95 +3170,95 @@ message EnumRules {
 
 // RepeatedRules describe the constraints applied to `repeated` values.
 message RepeatedRules {
-  //`min_items` requires that this field must contain at least the specified
-  //minimum number of items.
+  // `min_items` requires that this field must contain at least the specified
+  // minimum number of items.
   //
-  //```proto
-  //message MyRepeated {
-  //  // value must contain at least  2 items
-  //  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // value must contain at least  2 items
+  //   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+  // }
+  // ```
   optional uint64 min_items = 1 [(priv.field).cel = {
     id: "repeated.min_items"
     expression: "uint(this.size()) < rules.min_items ? 'value must contain at least %d item(s)'.format([rules.min_items]) : ''"
   }];
 
-  //`max_items` denotes that this field must not exceed a
-  //certain number of items as the upper limit. If the field contains more
-  //items than specified, an error message will be generated, requiring the
-  //field to maintain no more than the specified number of items.
+  // `max_items` denotes that this field must not exceed a
+  // certain number of items as the upper limit. If the field contains more
+  // items than specified, an error message will be generated, requiring the
+  // field to maintain no more than the specified number of items.
   //
-  //```proto
-  //message MyRepeated {
-  //  // value must contain no more than 3 item(s)
-  //  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // value must contain no more than 3 item(s)
+  //   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+  // }
+  // ```
   optional uint64 max_items = 2 [(priv.field).cel = {
     id: "repeated.max_items"
     expression: "uint(this.size()) > rules.max_items ? 'value must contain no more than %s item(s)'.format([rules.max_items]) : ''"
   }];
 
-  //`unique` indicates that all elements in this field must
-  //be unique. This constraint is strictly applicable to scalar and enum
-  //types, with message types not being supported.
+  // `unique` indicates that all elements in this field must
+  // be unique. This constraint is strictly applicable to scalar and enum
+  // types, with message types not being supported.
   //
-  //```proto
-  //message MyRepeated {
-  //  // repeated value must contain unique items
-  //  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // repeated value must contain unique items
+  //   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+  // }
+  // ```
   optional bool unique = 3 [(priv.field).cel = {
     id: "repeated.unique"
     message: "repeated value must contain unique items"
     expression: "this.unique()"
   }];
 
-  //`items` details the constraints to be applied to each item
-  //in the field. Even for repeated message fields, validation is executed
-  //against each item unless skip is explicitly specified.
+  // `items` details the constraints to be applied to each item
+  // in the field. Even for repeated message fields, validation is executed
+  // against each item unless skip is explicitly specified.
   //
-  //```proto
-  //message MyRepeated {
-  //  // The items in the field `value` must follow the specified constraints.
-  //  repeated string value = 1 [(buf.validate.field).repeated.items = {
-  //    string: {
-  //      min_len: 3
-  //      max_len: 10
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // The items in the field `value` must follow the specified constraints.
+  //   repeated string value = 1 [(buf.validate.field).repeated.items = {
+  //     string: {
+  //       min_len: 3
+  //       max_len: 10
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints items = 4;
 }
 
 // MapRules describe the constraints applied to `map` values.
 message MapRules {
   //Specifies the minimum number of key-value pairs allowed. If the field has
-  //fewer key-value pairs than specified, an error message is generated.
+  // fewer key-value pairs than specified, an error message is generated.
   //
-  //```proto
-  //message MyMap {
-  //  // The field `value` must have at least 2 key-value pairs.
-  //  map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The field `value` must have at least 2 key-value pairs.
+  //   map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
+  // }
+  // ```
   optional uint64 min_pairs = 1 [(priv.field).cel = {
     id: "map.min_pairs"
     expression: "uint(this.size()) < rules.min_pairs ? 'map must be at least %d entries'.format([rules.min_pairs]) : ''"
   }];
 
   //Specifies the maximum number of key-value pairs allowed. If the field has
-  //more key-value pairs than specified, an error message is generated.
+  // more key-value pairs than specified, an error message is generated.
   //
-  //```proto
-  //message MyMap {
-  //  // The field `value` must have at most 3 key-value pairs.
-  //  map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The field `value` must have at most 3 key-value pairs.
+  //   map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
+  // }
+  // ```
   optional uint64 max_pairs = 2 [(priv.field).cel = {
     id: "map.max_pairs"
     expression: "uint(this.size()) > rules.max_pairs ? 'map must be at most %d entries'.format([rules.max_pairs]) : ''"
@@ -3262,89 +3266,89 @@ message MapRules {
 
   //Specifies the constraints to be applied to each key in the field.
   //
-  //```proto
-  //message MyMap {
-  //  // The keys in the field `value` must follow the specified constraints.
-  //  map<string, string> value = 1 [(buf.validate.field).map.keys = {
-  //    string: {
-  //      min_len: 3
-  //      max_len: 10
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The keys in the field `value` must follow the specified constraints.
+  //   map<string, string> value = 1 [(buf.validate.field).map.keys = {
+  //     string: {
+  //       min_len: 3
+  //       max_len: 10
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints keys = 4;
 
   //Specifies the constraints to be applied to the value of each key in the
-  //field. Message values will still have their validations evaluated unless
+  // field. Message values will still have their validations evaluated unless
   //skip is specified here.
   //
-  //```proto
-  //message MyMap {
-  //  // The values in the field `value` must follow the specified constraints.
-  //  map<string, string> value = 1 [(buf.validate.field).map.values = {
-  //    string: {
-  //      min_len: 5
-  //      max_len: 20
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The values in the field `value` must follow the specified constraints.
+  //   map<string, string> value = 1 [(buf.validate.field).map.values = {
+  //     string: {
+  //       min_len: 5
+  //       max_len: 20
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints values = 5;
 }
 
 // AnyRules describe constraints applied exclusively to the `google.protobuf.Any` well-known type.
 message AnyRules {
-  //`in` requires the field's `type_url` to be equal to one of the
+  // `in` requires the field's `type_url` to be equal to one of the
   //specified values. If it doesn't match any of the specified values, an error
-  //message is generated.
+  // message is generated.
   //
-  //```proto
-  //message MyAny {
-  //  //  The `value` field must have a `type_url` equal to one of the specified values.
+  // ```proto
+  // message MyAny {
+  //   //  The `value` field must have a `type_url` equal to one of the specified values.
   //   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-  //}
-  //```
+  // }
+  // ```
   repeated string in = 2;
 
   // requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
   //
-  //```proto
-  //message MyAny {
-  //  // The field `value` must not have a `type_url` equal to any of the specified values.
+  // ```proto
+  // message MyAny {
+  //   // The field `value` must not have a `type_url` equal to any of the specified values.
   //   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-  //}
-  //```
+  // }
+  // ```
   repeated string not_in = 3;
 }
 
 // DurationRules describe the constraints applied exclusively to the `google.protobuf.Duration` well-known type.
 message DurationRules {
-  //`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-  //If the field's value deviates from the specified value, an error message
-  //will be generated.
+  // `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+  // If the field's value deviates from the specified value, an error message
+  // will be generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must equal 5s
+  // ```proto
+  // message MyDuration {
+  //   // value must equal 5s
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Duration const = 2 [(priv.field).cel = {
     id: "duration.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-    //exclusive. If the field's value is greater than or equal to the specified
-    //value, an error message will be generated.
+    // `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+    // exclusive. If the field's value is greater than or equal to the specified
+    // value, an error message will be generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // value must be less than 5s
+    // ```proto
+    // message MyDuration {
+    //   // value must be less than 5s
     //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration lt = 3 [(priv.field).cel = {
       id: "duration.lt",
       expression:
@@ -3352,16 +3356,16 @@ message DurationRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` indicates that the field must be less than or equal to the specified
-    //value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-    //an error message will be generated.
+    // `lte` indicates that the field must be less than or equal to the specified
+    // value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+    // an error message will be generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // value must be less than or equal to 10s
+    // ```proto
+    // message MyDuration {
+    //   // value must be less than or equal to 10s
     //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration lte = 4 [(priv.field).cel = {
       id: "duration.lte",
       expression:
@@ -3376,18 +3380,18 @@ message DurationRules {
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // duration must be greater than 5s [duration.gt]
-    //  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+    // ```proto
+    // message MyDuration {
+    //   // duration must be greater than 5s [duration.gt]
+    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
     //
-    //  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-    //  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+    //   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+    //   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
     //
-    //  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-    //  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-    //}
-    //```
+    //   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+    //   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+    // }
+    // ```
     google.protobuf.Duration gt = 5 [
       (priv.field).cel = {
         id: "duration.gt",
@@ -3427,8 +3431,8 @@ message DurationRules {
     // be outside the specified range. If the field value doesn't meet the
     // required conditions, an error message is generated.
     //
-    //```proto
-    //message MyDuration {
+    // ```proto
+    // message MyDuration {
     //  // duration must be greater than or equal to 5s [duration.gte]
     //  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
     //
@@ -3437,8 +3441,8 @@ message DurationRules {
     //
     //  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
     //  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration gte = 6 [
       (priv.field).cel = {
         id: "duration.gte",
@@ -3473,32 +3477,32 @@ message DurationRules {
     ];
   }
 
-  //`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-  //If the field's value doesn't correspond to any of the specified values,
-  //an error message will be generated.
+  // `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+  // If the field's value doesn't correspond to any of the specified values,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must be in list [1s, 2s, 3s]
+  // ```proto
+  // message MyDuration {
+  //   // value must be in list [1s, 2s, 3s]
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-  //}
-  //```
+  // }
+  // ```
   repeated google.protobuf.Duration in = 7 [(priv.field).cel = {
     id: "duration.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` denotes that the field must not be equal to
-  //any of the specified values of the `google.protobuf.Duration` type.
-  //If the field's value matches any of these values, an error message will be
-  //generated.
+  // `not_in` denotes that the field must not be equal to
+  // any of the specified values of the `google.protobuf.Duration` type.
+  // If the field's value matches any of these values, an error message will be
+  // generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must not be in list [1s, 2s, 3s]
+  // ```proto
+  // message MyDuration {
+  //   // value must not be in list [1s, 2s, 3s]
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-  //}
-  //```
+  // }
+  // ```
   repeated google.protobuf.Duration not_in = 8 [(priv.field).cel = {
     id: "duration.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -3507,14 +3511,14 @@ message DurationRules {
 
 // TimestampRules describe the constraints applied exclusively to the `google.protobuf.Timestamp` well-known type.
 message TimestampRules {
-  //`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+  // `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
   //
-  //```proto
-  //message MyTimestamp {
-  //  // value must equal 2023-05-03T10:00:00Z
+  // ```proto
+  // message MyTimestamp {
+  //   // value must equal 2023-05-03T10:00:00Z
   //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Timestamp const = 2 [(priv.field).cel = {
     id: "timestamp.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -3550,38 +3554,38 @@ message TimestampRules {
         "? 'value must be less than or equal to %s'.format([rules.lte]) : ''"
     }];
 
-    //`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+    // `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
     //
-    //```proto
-    //message MyTimestamp {
+    // ```proto
+    // message MyTimestamp {
     //  // value must be less than now
     //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-    //}
-    //```
+    // }
+    // ```
     bool lt_now = 7 [(priv.field).cel = {
       id: "timestamp.lt_now",
       expression: "this > now ? 'value must be less than now' : ''"
     }];
   }
   oneof greater_than {
-    //`gt` requires the timestamp field value to be greater than the specified
+    // `gt` requires the timestamp field value to be greater than the specified
     // value (exclusive). If the value of `gt` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-    //  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+    // ```proto
+    // message MyTimestamp {
+    //   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+    //   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
     //
-    //  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-    //  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+    //   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+    //   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
     //
-    //  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-    //  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-    //}
-    //```
+    //   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+    //   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+    // }
+    // ```
     google.protobuf.Timestamp gt = 5 [
       (priv.field).cel = {
         id: "timestamp.gt",
@@ -3615,24 +3619,24 @@ message TimestampRules {
       }
     ];
 
-    //`gte` requires the timestamp field value to be greater than or equal to the
+    // `gte` requires the timestamp field value to be greater than or equal to the
     // specified value (exclusive). If the value of `gte` is larger than a
     // specified `lt` or `lte`, the range is reversed, and the field value
     // must be outside the specified range. If the field value doesn't meet
     // the required conditions, an error message is generated.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-    //  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+    // ```proto
+    // message MyTimestamp {
+    //   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+    //   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
     //
-    //  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-    //  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+    //   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+    //   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
     //
-    //  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-    //  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-    //}
-    //```
+    //   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+    //   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+    // }
+    // ```
     google.protobuf.Timestamp gte = 6 [
       (priv.field).cel = {
         id: "timestamp.gte",
@@ -3666,14 +3670,14 @@ message TimestampRules {
       }
     ];
 
-    //`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+    // `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // value must be greater than now
+    // ```proto
+    // message MyTimestamp {
+    //   // value must be greater than now
     //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-    //}
-    //```
+    // }
+    // ```
     bool gt_now = 8 [(priv.field).cel = {
       id: "timestamp.gt_now",
       expression: "this < now ? 'value must be greater than now' : ''"
@@ -3682,12 +3686,12 @@ message TimestampRules {
 
   // `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
   //
-  //```proto
-  //message MyTimestamp {
-  //  // value must be within 1 hour of now
+  // ```proto
+  // message MyTimestamp {
+  //   // value must be within 1 hour of now
   //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Duration within = 9 [(priv.field).cel = {
     id: "timestamp.within",
     expression: "this < now-rules.within || this > now+rules.within ? 'value must be within %s of now'.format([rules.within]) : ''"

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -97,7 +97,7 @@ type MessageConstraints struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+	// `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
 	// This includes any fields within the message that would otherwise support validation.
 	//
 	// ```proto
@@ -109,20 +109,20 @@ type MessageConstraints struct {
 	//
 	// ```
 	Disabled *bool `protobuf:"varint,1,opt,name=disabled,proto3,oneof" json:"disabled,omitempty"`
-	// cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+	// `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
 	// These constraints are written in Common Expression Language (CEL) syntax. For more information on
 	// CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
 	//
 	// ```proto
 	//
 	//	message MyMessage {
-	//	 // The field `foo` must be greater than 42.
-	//	 option (buf.validate.message).cel = {
-	//	   id: "my_message.value",
-	//	   message: "value must be greater than 42",
-	//	   expression: "this.foo > 42",
-	//	 };
-	//	 optional int32 foo = 1;
+	//	  // The field `foo` must be greater than 42.
+	//	  option (buf.validate.message).cel = {
+	//	    id: "my_message.value",
+	//	    message: "value must be greater than 42",
+	//	    expression: "this.foo > 42",
+	//	  };
+	//	  optional int32 foo = 1;
 	//	}
 	//
 	// ```
@@ -191,12 +191,12 @@ type OneofConstraints struct {
 	// ```proto
 	//
 	//	message MyMessage {
-	//	 oneof value {
-	//	   // The field `a` or `b` must be set.
-	//	   option (buf.validate.oneof).required = true;
-	//	   optional string a = 1;
-	//	   optional string b = 2;
-	//	 }
+	//	  oneof value {
+	//	    // The field `a` or `b` must be set.
+	//	    option (buf.validate.oneof).required = true;
+	//	    optional string a = 1;
+	//	    optional string b = 2;
+	//	  }
 	//	}
 	//
 	// ```
@@ -249,19 +249,19 @@ type FieldConstraints struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// `Constraint` is a repeated field used to represent a textual expression
+	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information on
 	// CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
 	//
 	// ```proto
 	//
 	//	message MyMessage {
-	//	 // The field `value` must be greater than 42.
-	//	 optional int32 value = 1 [(buf.validate.field).cel = {
-	//	   id: "my_message.value",
-	//	   message: "value must be greater than 42",
-	//	   expression: "this > 42",
-	//	 }];
+	//	  // The field `value` must be greater than 42.
+	//	  optional int32 value = 1 [(buf.validate.field).cel = {
+	//	    id: "my_message.value",
+	//	    message: "value must be greater than 42",
+	//	    expression: "this > 42",
+	//	  }];
 	//	}
 	//
 	// ```
@@ -273,8 +273,8 @@ type FieldConstraints struct {
 	// ```proto
 	//
 	//	message MyMessage {
-	//	 // The field `value` must not be set.
-	//	 optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+	//	  // The field `value` must not be set.
+	//	  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
 	//	}
 	//
 	// ```
@@ -283,11 +283,15 @@ type FieldConstraints struct {
 	// this field must be set. If required is set to true, the field value must
 	// not be empty; otherwise, an error message will be generated.
 	//
+	// Note that `required` does *not* validate that repeated fields are non-empty.
+	// If you'd like to validate that a `repeated` field is non-empty, use
+	// `repeated.min_items = 1`.
+	//
 	// ```proto
 	//
 	//	message MyMessage {
-	//	 // The field `value` must be set.
-	//	 optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+	//	  // The field `value` must be set.
+	//	  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
 	//	}
 	//
 	// ```
@@ -299,8 +303,8 @@ type FieldConstraints struct {
 	// ```proto
 	//
 	//	message MyRepeated {
-	//	 // The field `value` validation rules should be evaluated only if the field isn't empty.
-	//	 repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+	//	  // The field `value` validation rules should be evaluated only if the field isn't empty.
+	//	  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
 	//	}
 	//
 	// ```
@@ -691,7 +695,7 @@ type FloatRules struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must equal 42.0
+	//	  // value must equal 42.0
 	//	  float value = 1 [(buf.validate.field).float.const = 42.0];
 	//	}
 	//
@@ -714,8 +718,8 @@ type FloatRules struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must be in list [1.0, 2.0, 3.0]
-	//	 repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+	//	  // value must be in list [1.0, 2.0, 3.0]
+	//	  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
 	//	}
 	//
 	// ```
@@ -727,8 +731,8 @@ type FloatRules struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must not be in list [1.0, 2.0, 3.0]
-	//	 repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+	//	  // value must not be in list [1.0, 2.0, 3.0]
+	//	  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
 	//	}
 	//
 	// ```
@@ -852,7 +856,7 @@ type FloatRules_Lt struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must be less than 10.0
+	//	  // value must be less than 10.0
 	//	  float value = 1 [(buf.validate.field).float.lt = 10.0];
 	//	}
 	//
@@ -868,7 +872,7 @@ type FloatRules_Lte struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must be less than or equal to 10.0
+	//	  // value must be less than or equal to 10.0
 	//	  float value = 1 [(buf.validate.field).float.lte = 10.0];
 	//	}
 	//
@@ -894,14 +898,14 @@ type FloatRules_Gt struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must be greater than 5.0 [float.gt]
-	//	 float value = 1 [(buf.validate.field).float.gt = 5.0];
+	//	  // value must be greater than 5.0 [float.gt]
+	//	  float value = 1 [(buf.validate.field).float.gt = 5.0];
 	//
-	//	 // value must be greater than 5 and less than 10.0 [float.gt_lt]
-	//	 float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+	//	  // value must be greater than 5 and less than 10.0 [float.gt_lt]
+	//	  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
 	//
-	//	 // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-	//	 float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+	//	  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+	//	  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
 	//	}
 	//
 	// ```
@@ -918,14 +922,14 @@ type FloatRules_Gte struct {
 	// ```proto
 	//
 	//	message MyFloat {
-	//	 // value must be greater than or equal to 5.0 [float.gte]
-	//	 float value = 1 [(buf.validate.field).float.gte = 5.0];
+	//	  // value must be greater than or equal to 5.0 [float.gte]
+	//	  float value = 1 [(buf.validate.field).float.gte = 5.0];
 	//
-	//	 // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-	//	 float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+	//	  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+	//	  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
 	//
-	//	 // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-	//	 float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+	//	  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+	//	  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
 	//	}
 	//
 	// ```
@@ -949,7 +953,7 @@ type DoubleRules struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must equal 42.0
+	//	  // value must equal 42.0
 	//	  double value = 1 [(buf.validate.field).double.const = 42.0];
 	//	}
 	//
@@ -972,8 +976,8 @@ type DoubleRules struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must be in list [1.0, 2.0, 3.0]
-	//	 repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+	//	  // value must be in list [1.0, 2.0, 3.0]
+	//	  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
 	//	}
 	//
 	// ```
@@ -985,8 +989,8 @@ type DoubleRules struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must not be in list [1.0, 2.0, 3.0]
-	//	 repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+	//	  // value must not be in list [1.0, 2.0, 3.0]
+	//	  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
 	//	}
 	//
 	// ```
@@ -1110,7 +1114,7 @@ type DoubleRules_Lt struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must be less than 10.0
+	//	  // value must be less than 10.0
 	//	  double value = 1 [(buf.validate.field).double.lt = 10.0];
 	//	}
 	//
@@ -1126,7 +1130,7 @@ type DoubleRules_Lte struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must be less than or equal to 10.0
+	//	  // value must be less than or equal to 10.0
 	//	  double value = 1 [(buf.validate.field).double.lte = 10.0];
 	//	}
 	//
@@ -1152,14 +1156,14 @@ type DoubleRules_Gt struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must be greater than 5.0 [double.gt]
-	//	 double value = 1 [(buf.validate.field).double.gt = 5.0];
+	//	  // value must be greater than 5.0 [double.gt]
+	//	  double value = 1 [(buf.validate.field).double.gt = 5.0];
 	//
-	//	 // value must be greater than 5 and less than 10.0 [double.gt_lt]
-	//	 double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+	//	  // value must be greater than 5 and less than 10.0 [double.gt_lt]
+	//	  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
 	//
-	//	 // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-	//	 double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+	//	  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+	//	  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
 	//	}
 	//
 	// ```
@@ -1176,14 +1180,14 @@ type DoubleRules_Gte struct {
 	// ```proto
 	//
 	//	message MyDouble {
-	//	 // value must be greater than or equal to 5.0 [double.gte]
-	//	 double value = 1 [(buf.validate.field).double.gte = 5.0];
+	//	  // value must be greater than or equal to 5.0 [double.gte]
+	//	  double value = 1 [(buf.validate.field).double.gte = 5.0];
 	//
-	//	 // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-	//	 double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+	//	  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+	//	  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
 	//
-	//	 // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-	//	 double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+	//	  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+	//	  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
 	//	}
 	//
 	// ```
@@ -1207,7 +1211,7 @@ type Int32Rules struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  int32 value = 1 [(buf.validate.field).int32.const = 42];
 	//	}
 	//
@@ -1230,8 +1234,8 @@ type Int32Rules struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1243,8 +1247,8 @@ type Int32Rules struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1358,7 +1362,7 @@ type Int32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  int32 value = 1 [(buf.validate.field).int32.lt = 10];
 	//	}
 	//
@@ -1374,7 +1378,7 @@ type Int32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  int32 value = 1 [(buf.validate.field).int32.lte = 10];
 	//	}
 	//
@@ -1400,14 +1404,14 @@ type Int32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must be greater than 5 [int32.gt]
-	//	 int32 value = 1 [(buf.validate.field).int32.gt = 5];
+	//	  // value must be greater than 5 [int32.gt]
+	//	  int32 value = 1 [(buf.validate.field).int32.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [int32.gt_lt]
-	//	 int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [int32.gt_lt]
+	//	  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-	//	 int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+	//	  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1424,14 +1428,14 @@ type Int32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyInt32 {
-	//	 // value must be greater than or equal to 5 [int32.gte]
-	//	 int32 value = 1 [(buf.validate.field).int32.gte = 5];
+	//	  // value must be greater than or equal to 5 [int32.gte]
+	//	  int32 value = 1 [(buf.validate.field).int32.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-	//	 int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+	//	  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-	//	 int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+	//	  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1455,7 +1459,7 @@ type Int64Rules struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  int64 value = 1 [(buf.validate.field).int64.const = 42];
 	//	}
 	//
@@ -1478,8 +1482,8 @@ type Int64Rules struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1491,8 +1495,8 @@ type Int64Rules struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1606,7 +1610,7 @@ type Int64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  int64 value = 1 [(buf.validate.field).int64.lt = 10];
 	//	}
 	//
@@ -1622,7 +1626,7 @@ type Int64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  int64 value = 1 [(buf.validate.field).int64.lte = 10];
 	//	}
 	//
@@ -1648,14 +1652,14 @@ type Int64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must be greater than 5 [int64.gt]
-	//	 int64 value = 1 [(buf.validate.field).int64.gt = 5];
+	//	  // value must be greater than 5 [int64.gt]
+	//	  int64 value = 1 [(buf.validate.field).int64.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [int64.gt_lt]
-	//	 int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [int64.gt_lt]
+	//	  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-	//	 int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+	//	  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1672,14 +1676,14 @@ type Int64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyInt64 {
-	//	 // value must be greater than or equal to 5 [int64.gte]
-	//	 int64 value = 1 [(buf.validate.field).int64.gte = 5];
+	//	  // value must be greater than or equal to 5 [int64.gte]
+	//	  int64 value = 1 [(buf.validate.field).int64.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-	//	 int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+	//	  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-	//	 int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+	//	  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1703,7 +1707,7 @@ type UInt32Rules struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  uint32 value = 1 [(buf.validate.field).uint32.const = 42];
 	//	}
 	//
@@ -1726,8 +1730,8 @@ type UInt32Rules struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1739,8 +1743,8 @@ type UInt32Rules struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1854,7 +1858,7 @@ type UInt32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
 	//	}
 	//
@@ -1870,7 +1874,7 @@ type UInt32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
 	//	}
 	//
@@ -1896,14 +1900,14 @@ type UInt32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must be greater than 5 [uint32.gt]
-	//	 uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+	//	  // value must be greater than 5 [uint32.gt]
+	//	  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [uint32.gt_lt]
-	//	 uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [uint32.gt_lt]
+	//	  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-	//	 uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+	//	  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1920,14 +1924,14 @@ type UInt32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyUInt32 {
-	//	 // value must be greater than or equal to 5 [uint32.gte]
-	//	 uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+	//	  // value must be greater than or equal to 5 [uint32.gte]
+	//	  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-	//	 uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+	//	  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-	//	 uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+	//	  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -1951,7 +1955,7 @@ type UInt64Rules struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  uint64 value = 1 [(buf.validate.field).uint64.const = 42];
 	//	}
 	//
@@ -1974,8 +1978,8 @@ type UInt64Rules struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -1987,8 +1991,8 @@ type UInt64Rules struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2102,7 +2106,7 @@ type UInt64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
 	//	}
 	//
@@ -2118,7 +2122,7 @@ type UInt64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
 	//	}
 	//
@@ -2144,14 +2148,14 @@ type UInt64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must be greater than 5 [uint64.gt]
-	//	 uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+	//	  // value must be greater than 5 [uint64.gt]
+	//	  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [uint64.gt_lt]
-	//	 uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [uint64.gt_lt]
+	//	  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-	//	 uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+	//	  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2168,14 +2172,14 @@ type UInt64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyUInt64 {
-	//	 // value must be greater than or equal to 5 [uint64.gte]
-	//	 uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+	//	  // value must be greater than or equal to 5 [uint64.gte]
+	//	  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-	//	 uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+	//	  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-	//	 uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+	//	  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2198,7 +2202,7 @@ type SInt32Rules struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  sint32 value = 1 [(buf.validate.field).sint32.const = 42];
 	//	}
 	//
@@ -2221,8 +2225,8 @@ type SInt32Rules struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2234,8 +2238,8 @@ type SInt32Rules struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2349,7 +2353,7 @@ type SInt32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
 	//	}
 	//
@@ -2365,7 +2369,7 @@ type SInt32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
 	//	}
 	//
@@ -2391,14 +2395,14 @@ type SInt32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySInt32 {
-	//	 // value must be greater than 5 [sint32.gt]
-	//	 sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+	//	  // value must be greater than 5 [sint32.gt]
+	//	  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [sint32.gt_lt]
-	//	 sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [sint32.gt_lt]
+	//	  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-	//	 sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+	//	  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2445,7 +2449,7 @@ type SInt64Rules struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  sint64 value = 1 [(buf.validate.field).sint64.const = 42];
 	//	}
 	//
@@ -2468,8 +2472,8 @@ type SInt64Rules struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2481,8 +2485,8 @@ type SInt64Rules struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2596,7 +2600,7 @@ type SInt64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
 	//	}
 	//
@@ -2612,7 +2616,7 @@ type SInt64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
 	//	}
 	//
@@ -2638,14 +2642,14 @@ type SInt64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must be greater than 5 [sint64.gt]
-	//	 sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+	//	  // value must be greater than 5 [sint64.gt]
+	//	  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [sint64.gt_lt]
-	//	 sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [sint64.gt_lt]
+	//	  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-	//	 sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+	//	  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2662,14 +2666,14 @@ type SInt64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySInt64 {
-	//	 // value must be greater than or equal to 5 [sint64.gte]
-	//	 sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+	//	  // value must be greater than or equal to 5 [sint64.gte]
+	//	  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-	//	 sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+	//	  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-	//	 sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+	//	  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2692,7 +2696,7 @@ type Fixed32Rules struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
 	//	}
 	//
@@ -2715,8 +2719,8 @@ type Fixed32Rules struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2728,8 +2732,8 @@ type Fixed32Rules struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2843,7 +2847,7 @@ type Fixed32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
 	//	}
 	//
@@ -2859,7 +2863,7 @@ type Fixed32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
 	//	}
 	//
@@ -2885,14 +2889,14 @@ type Fixed32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must be greater than 5 [fixed32.gt]
-	//	 fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+	//	  // value must be greater than 5 [fixed32.gt]
+	//	  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-	//	 fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+	//	  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-	//	 fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+	//	  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2909,14 +2913,14 @@ type Fixed32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyFixed32 {
-	//	 // value must be greater than or equal to 5 [fixed32.gte]
-	//	 fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+	//	  // value must be greater than or equal to 5 [fixed32.gte]
+	//	  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-	//	 fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+	//	  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-	//	 fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+	//	  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -2939,7 +2943,7 @@ type Fixed64Rules struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
 	//	}
 	//
@@ -2962,8 +2966,8 @@ type Fixed64Rules struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -2975,8 +2979,8 @@ type Fixed64Rules struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -3090,7 +3094,7 @@ type Fixed64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
 	//	}
 	//
@@ -3106,7 +3110,7 @@ type Fixed64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
 	//	}
 	//
@@ -3132,14 +3136,14 @@ type Fixed64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must be greater than 5 [fixed64.gt]
-	//	 fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+	//	  // value must be greater than 5 [fixed64.gt]
+	//	  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-	//	 fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+	//	  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-	//	 fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+	//	  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3156,14 +3160,14 @@ type Fixed64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MyFixed64 {
-	//	 // value must be greater than or equal to 5 [fixed64.gte]
-	//	 fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+	//	  // value must be greater than or equal to 5 [fixed64.gte]
+	//	  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-	//	 fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+	//	  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-	//	 fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+	//	  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3186,7 +3190,7 @@ type SFixed32Rules struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
 	//	}
 	//
@@ -3209,8 +3213,8 @@ type SFixed32Rules struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -3222,8 +3226,8 @@ type SFixed32Rules struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -3337,7 +3341,7 @@ type SFixed32Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
 	//	}
 	//
@@ -3353,7 +3357,7 @@ type SFixed32Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
 	//	}
 	//
@@ -3379,14 +3383,14 @@ type SFixed32Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must be greater than 5 [sfixed32.gt]
-	//	 sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+	//	  // value must be greater than 5 [sfixed32.gt]
+	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-	//	 sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+	//	  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-	//	 sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+	//	  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3403,14 +3407,14 @@ type SFixed32Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySFixed32 {
-	//	 // value must be greater than or equal to 5 [sfixed32.gte]
-	//	 sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+	//	  // value must be greater than or equal to 5 [sfixed32.gte]
+	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-	//	 sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+	//	  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-	//	 sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+	//	  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3433,7 +3437,7 @@ type SFixed64Rules struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must equal 42
+	//	  // value must equal 42
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
 	//	}
 	//
@@ -3456,8 +3460,8 @@ type SFixed64Rules struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must be in list [1, 2, 3]
-	//	 repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+	//	  // value must be in list [1, 2, 3]
+	//	  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -3469,8 +3473,8 @@ type SFixed64Rules struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must not be in list [1, 2, 3]
-	//	 repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+	//	  // value must not be in list [1, 2, 3]
+	//	  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
 	//	}
 	//
 	// ```
@@ -3584,7 +3588,7 @@ type SFixed64Rules_Lt struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must be less than 10
+	//	  // value must be less than 10
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
 	//	}
 	//
@@ -3600,7 +3604,7 @@ type SFixed64Rules_Lte struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must be less than or equal to 10
+	//	  // value must be less than or equal to 10
 	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
 	//	}
 	//
@@ -3626,14 +3630,14 @@ type SFixed64Rules_Gt struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must be greater than 5 [sfixed64.gt]
-	//	 sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+	//	  // value must be greater than 5 [sfixed64.gt]
+	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
 	//
-	//	 // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-	//	 sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+	//	  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+	//	  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
 	//
-	//	 // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-	//	 sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+	//	  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+	//	  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3650,14 +3654,14 @@ type SFixed64Rules_Gte struct {
 	// ```proto
 	//
 	//	message MySFixed64 {
-	//	 // value must be greater than or equal to 5 [sfixed64.gte]
-	//	 sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+	//	  // value must be greater than or equal to 5 [sfixed64.gte]
+	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
 	//
-	//	 // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-	//	 sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+	//	  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+	//	  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
 	//
-	//	 // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-	//	 sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+	//	  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+	//	  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
 	//	}
 	//
 	// ```
@@ -3681,7 +3685,7 @@ type BoolRules struct {
 	// ```proto
 	//
 	//	message MyBool {
-	//	 // value must equal true
+	//	  // value must equal true
 	//	  bool value = 1 [(buf.validate.field).bool.const = true];
 	//	}
 	//
@@ -3741,7 +3745,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must equal `hello`
+	//	  // value must equal `hello`
 	//	  string value = 1 [(buf.validate.field).string.const = "hello"];
 	//	}
 	//
@@ -3755,7 +3759,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be 5 characters
+	//	  // value length must be 5 characters
 	//	  string value = 1 [(buf.validate.field).string.len = 5];
 	//	}
 	//
@@ -3769,7 +3773,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be at least 3 characters
+	//	  // value length must be at least 3 characters
 	//	  string value = 1 [(buf.validate.field).string.min_len = 3];
 	//	}
 	//
@@ -3783,7 +3787,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be at most 10 characters
+	//	  // value length must be at most 10 characters
 	//	  string value = 1 [(buf.validate.field).string.max_len = 10];
 	//	}
 	//
@@ -3796,7 +3800,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be 6 bytes
+	//	  // value length must be 6 bytes
 	//	  string value = 1 [(buf.validate.field).string.len_bytes = 6];
 	//	}
 	//
@@ -3809,7 +3813,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be at least 4 bytes
+	//	  // value length must be at least 4 bytes
 	//	  string value = 1 [(buf.validate.field).string.min_bytes = 4];
 	//	}
 	//
@@ -3822,7 +3826,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value length must be at most 8 bytes
+	//	  // value length must be at most 8 bytes
 	//	  string value = 1 [(buf.validate.field).string.max_bytes = 8];
 	//	}
 	//
@@ -3836,7 +3840,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value does not match regex pattern `^[a-zA-Z]//$`
+	//	  // value does not match regex pattern `^[a-zA-Z]//$`
 	//	  string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
 	//	}
 	//
@@ -3850,7 +3854,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value does not have prefix `pre`
+	//	  // value does not have prefix `pre`
 	//	  string value = 1 [(buf.validate.field).string.prefix = "pre"];
 	//	}
 	//
@@ -3863,7 +3867,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value does not have suffix `post`
+	//	  // value does not have suffix `post`
 	//	  string value = 1 [(buf.validate.field).string.suffix = "post"];
 	//	}
 	//
@@ -3876,7 +3880,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value does not contain substring `inside`.
+	//	  // value does not contain substring `inside`.
 	//	  string value = 1 [(buf.validate.field).string.contains = "inside"];
 	//	}
 	//
@@ -3889,7 +3893,7 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value contains substring `inside`.
+	//	  // value contains substring `inside`.
 	//	  string value = 1 [(buf.validate.field).string.not_contains = "inside"];
 	//	}
 	//
@@ -3902,8 +3906,8 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be in list ["apple", "banana"]
-	//	 repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+	//	  // value must be in list ["apple", "banana"]
+	//	  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
 	//	}
 	//
 	// ```
@@ -3914,8 +3918,8 @@ type StringRules struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must not be in list ["orange", "grape"]
-	//	 repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+	//	  // value must not be in list ["orange", "grape"]
+	//	  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
 	//	}
 	//
 	// ```
@@ -4179,7 +4183,7 @@ type StringRules_Email struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid email address
+	//	  // value must be a valid email address
 	//	  string value = 1 [(buf.validate.field).string.email = true];
 	//	}
 	//
@@ -4196,7 +4200,7 @@ type StringRules_Hostname struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid hostname
+	//	  // value must be a valid hostname
 	//	  string value = 1 [(buf.validate.field).string.hostname = true];
 	//	}
 	//
@@ -4213,7 +4217,7 @@ type StringRules_Ip struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid IP address
+	//	  // value must be a valid IP address
 	//	  string value = 1 [(buf.validate.field).string.ip = true];
 	//	}
 	//
@@ -4229,7 +4233,7 @@ type StringRules_Ipv4 struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid IPv4 address
+	//	  // value must be a valid IPv4 address
 	//	  string value = 1 [(buf.validate.field).string.ipv4 = true];
 	//	}
 	//
@@ -4245,7 +4249,7 @@ type StringRules_Ipv6 struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid IPv6 address
+	//	  // value must be a valid IPv6 address
 	//	  string value = 1 [(buf.validate.field).string.ipv6 = true];
 	//	}
 	//
@@ -4261,7 +4265,7 @@ type StringRules_Uri struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid URI
+	//	  // value must be a valid URI
 	//	  string value = 1 [(buf.validate.field).string.uri = true];
 	//	}
 	//
@@ -4277,7 +4281,7 @@ type StringRules_UriRef struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid URI
+	//	  // value must be a valid URI
 	//	  string value = 1 [(buf.validate.field).string.uri_ref = true];
 	//	}
 	//
@@ -4295,7 +4299,7 @@ type StringRules_Address struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid hostname, or ip address
+	//	  // value must be a valid hostname, or ip address
 	//	  string value = 1 [(buf.validate.field).string.address = true];
 	//	}
 	//
@@ -4311,7 +4315,7 @@ type StringRules_Uuid struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid UUID
+	//	  // value must be a valid UUID
 	//	  string value = 1 [(buf.validate.field).string.uuid = true];
 	//	}
 	//
@@ -4327,7 +4331,7 @@ type StringRules_WellKnownRegex struct {
 	// ```proto
 	//
 	//	message MyString {
-	//	 // value must be a valid HTTP header value
+	//	  // value must be a valid HTTP header value
 	//	  string value = 1 [(buf.validate.field).string.well_known_regex = 2];
 	//	}
 	//
@@ -4378,7 +4382,7 @@ type BytesRules struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	 // value must be "\x01\x02\x03\x04"
+	//	  // value must be "\x01\x02\x03\x04"
 	//	  bytes value = 1 [(buf.validate.field).bytes.const = "\x01\x02\x03\x04"];
 	//	}
 	//
@@ -4390,8 +4394,8 @@ type BytesRules struct {
 	// ```proto
 	//
 	//	message MyBytes {
-	//	     // value length must be 4 bytes.
-	//	     optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+	//	  // value length must be 4 bytes.
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
 	//	}
 	//
 	// ```
@@ -4401,10 +4405,12 @@ type BytesRules struct {
 	// If the field value doesn't meet the requirement, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value length must be at least 2 bytes.
-	// optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value length must be at least 2 bytes.
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+	//	}
+	//
 	// ```
 	MinLen *uint64 `protobuf:"varint,2,opt,name=min_len,json=minLen,proto3,oneof" json:"min_len,omitempty"`
 	// `max_len` requires the field value to have at most the specified maximum
@@ -4412,10 +4418,12 @@ type BytesRules struct {
 	// If the field value exceeds the requirement, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value must be at most 6 bytes.
-	// optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must be at most 6 bytes.
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+	//	}
+	//
 	// ```
 	MaxLen *uint64 `protobuf:"varint,3,opt,name=max_len,json=maxLen,proto3,oneof" json:"max_len,omitempty"`
 	// `pattern` requires the field value to match the specified regular
@@ -4425,10 +4433,12 @@ type BytesRules struct {
 	// If the field value doesn't match the pattern, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value must match regex pattern "^[a-zA-Z0-9]+$".
-	// optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must match regex pattern "^[a-zA-Z0-9]+$".
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+	//	}
+	//
 	// ```
 	Pattern *string `protobuf:"bytes,4,opt,name=pattern,proto3,oneof" json:"pattern,omitempty"`
 	// `prefix` requires the field value to have the specified bytes at the
@@ -4436,10 +4446,12 @@ type BytesRules struct {
 	// If the field value doesn't meet the requirement, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value does not have prefix \x01\x02
-	// optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value does not have prefix \x01\x02
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
+	//	}
+	//
 	// ```
 	Prefix []byte `protobuf:"bytes,5,opt,name=prefix,proto3,oneof" json:"prefix,omitempty"`
 	// `suffix` requires the field value to have the specified bytes at the end
@@ -4447,10 +4459,12 @@ type BytesRules struct {
 	// If the field value doesn't meet the requirement, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value does not have suffix \x03\x04
-	// optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value does not have suffix \x03\x04
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
+	//	}
+	//
 	// ```
 	Suffix []byte `protobuf:"bytes,6,opt,name=suffix,proto3,oneof" json:"suffix,omitempty"`
 	// `contains` requires the field value to have the specified bytes anywhere in
@@ -4458,10 +4472,12 @@ type BytesRules struct {
 	// If the field value doesn't meet the requirement, an error message is generated.
 	//
 	// ```protobuf
-	// message MyBytes {
-	// // value does not contain \x02\x03
-	// optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value does not contain \x02\x03
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
+	//	}
+	//
 	// ```
 	Contains []byte `protobuf:"bytes,7,opt,name=contains,proto3,oneof" json:"contains,omitempty"`
 	// `in` requires the field value to be equal to one of the specified
@@ -4469,10 +4485,12 @@ type BytesRules struct {
 	// error message is generated.
 	//
 	// ```protobuf
-	// message MyBytes {
-	// // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
-	// optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+	//	}
+	//
 	// ```
 	In [][]byte `protobuf:"bytes,8,rep,name=in,proto3" json:"in,omitempty"`
 	// `not_in` requires the field value to be not equal to any of the specified
@@ -4481,10 +4499,12 @@ type BytesRules struct {
 	// generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
-	// optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+	//	}
+	//
 	// ```
 	NotIn [][]byte `protobuf:"bytes,9,rep,name=not_in,json=notIn,proto3" json:"not_in,omitempty"`
 	// WellKnown rules provide advanced constraints against common byte
@@ -4637,10 +4657,12 @@ type BytesRules_Ip struct {
 	// If the field value doesn't meet this constraint, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value must be a valid IP address
-	// optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must be a valid IP address
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+	//	}
+	//
 	// ```
 	Ip bool `protobuf:"varint,10,opt,name=ip,proto3,oneof"`
 }
@@ -4650,10 +4672,12 @@ type BytesRules_Ipv4 struct {
 	// If the field value doesn't meet this constraint, an error message is generated.
 	//
 	// ```proto
-	// message MyBytes {
-	// // value must be a valid IPv4 address
-	// optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must be a valid IPv4 address
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+	//	}
+	//
 	// ```
 	Ipv4 bool `protobuf:"varint,11,opt,name=ipv4,proto3,oneof"`
 }
@@ -4662,10 +4686,12 @@ type BytesRules_Ipv6 struct {
 	// `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
 	// If the field value doesn't meet this constraint, an error message is generated.
 	// ```proto
-	// message MyBytes {
-	// // value must be a valid IPv6 address
-	// optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-	// }
+	//
+	//	message MyBytes {
+	//	  // value must be a valid IPv6 address
+	//	  optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+	//	}
+	//
 	// ```
 	Ipv6 bool `protobuf:"varint,12,opt,name=ipv6,proto3,oneof"`
 }
@@ -4688,13 +4714,13 @@ type EnumRules struct {
 	// ```proto
 	//
 	//	enum MyEnum {
-	//	 MY_ENUM_UNSPECIFIED = 0;
-	//	 MY_ENUM_VALUE1 = 1;
-	//	 MY_ENUM_VALUE2 = 2;
+	//	  MY_ENUM_UNSPECIFIED = 0;
+	//	  MY_ENUM_VALUE1 = 1;
+	//	  MY_ENUM_VALUE2 = 2;
 	//	}
 	//
 	//	message MyMessage {
-	//	 // The field `value` must be exactly MY_ENUM_VALUE1.
+	//	  // The field `value` must be exactly MY_ENUM_VALUE1.
 	//	  MyEnum value = 1 [(buf.validate.field).enum.const = 1];
 	//	}
 	//
@@ -4706,13 +4732,13 @@ type EnumRules struct {
 	// ```proto
 	//
 	//	enum MyEnum {
-	//	 MY_ENUM_UNSPECIFIED = 0;
-	//	 MY_ENUM_VALUE1 = 1;
-	//	 MY_ENUM_VALUE2 = 2;
+	//	  MY_ENUM_UNSPECIFIED = 0;
+	//	  MY_ENUM_VALUE1 = 1;
+	//	  MY_ENUM_VALUE2 = 2;
 	//	}
 	//
 	//	message MyMessage {
-	//	 // The field `value` must be a defined value of MyEnum.
+	//	  // The field `value` must be a defined value of MyEnum.
 	//	  MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
 	//	}
 	//
@@ -4725,13 +4751,13 @@ type EnumRules struct {
 	// ```proto
 	//
 	//	enum MyEnum {
-	//	 MY_ENUM_UNSPECIFIED = 0;
-	//	 MY_ENUM_VALUE1 = 1;
-	//	 MY_ENUM_VALUE2 = 2;
+	//	  MY_ENUM_UNSPECIFIED = 0;
+	//	  MY_ENUM_VALUE1 = 1;
+	//	  MY_ENUM_VALUE2 = 2;
 	//	}
 	//
 	//	message MyMessage {
-	//	 // The field `value` must be equal to one of the specified values.
+	//	  // The field `value` must be equal to one of the specified values.
 	//	  MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
 	//	}
 	//
@@ -4744,13 +4770,13 @@ type EnumRules struct {
 	// ```proto
 	//
 	//	enum MyEnum {
-	//	 MY_ENUM_UNSPECIFIED = 0;
-	//	 MY_ENUM_VALUE1 = 1;
-	//	 MY_ENUM_VALUE2 = 2;
+	//	  MY_ENUM_UNSPECIFIED = 0;
+	//	  MY_ENUM_VALUE1 = 1;
+	//	  MY_ENUM_VALUE2 = 2;
 	//	}
 	//
 	//	message MyMessage {
-	//	 // The field `value` must not be equal to any of the specified values.
+	//	  // The field `value` must not be equal to any of the specified values.
 	//	  MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
 	//	}
 	//
@@ -4830,8 +4856,8 @@ type RepeatedRules struct {
 	// ```proto
 	//
 	//	message MyRepeated {
-	//	 // value must contain at least  2 items
-	//	 repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+	//	  // value must contain at least  2 items
+	//	  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
 	//	}
 	//
 	// ```
@@ -4844,8 +4870,8 @@ type RepeatedRules struct {
 	// ```proto
 	//
 	//	message MyRepeated {
-	//	 // value must contain no more than 3 item(s)
-	//	 repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+	//	  // value must contain no more than 3 item(s)
+	//	  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
 	//	}
 	//
 	// ```
@@ -4857,8 +4883,8 @@ type RepeatedRules struct {
 	// ```proto
 	//
 	//	message MyRepeated {
-	//	 // repeated value must contain unique items
-	//	 repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+	//	  // repeated value must contain unique items
+	//	  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
 	//	}
 	//
 	// ```
@@ -4870,13 +4896,13 @@ type RepeatedRules struct {
 	// ```proto
 	//
 	//	message MyRepeated {
-	//	 // The items in the field `value` must follow the specified constraints.
-	//	 repeated string value = 1 [(buf.validate.field).repeated.items = {
-	//	   string: {
-	//	     min_len: 3
-	//	     max_len: 10
-	//	   }
-	//	 }];
+	//	  // The items in the field `value` must follow the specified constraints.
+	//	  repeated string value = 1 [(buf.validate.field).repeated.items = {
+	//	    string: {
+	//	      min_len: 3
+	//	      max_len: 10
+	//	    }
+	//	  }];
 	//	}
 	//
 	// ```
@@ -4955,8 +4981,8 @@ type MapRules struct {
 	// ```proto
 	//
 	//	message MyMap {
-	//	 // The field `value` must have at least 2 key-value pairs.
-	//	 map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
+	//	  // The field `value` must have at least 2 key-value pairs.
+	//	  map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
 	//	}
 	//
 	// ```
@@ -4967,8 +4993,8 @@ type MapRules struct {
 	// ```proto
 	//
 	//	message MyMap {
-	//	 // The field `value` must have at most 3 key-value pairs.
-	//	 map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
+	//	  // The field `value` must have at most 3 key-value pairs.
+	//	  map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
 	//	}
 	//
 	// ```
@@ -4978,13 +5004,13 @@ type MapRules struct {
 	// ```proto
 	//
 	//	message MyMap {
-	//	 // The keys in the field `value` must follow the specified constraints.
-	//	 map<string, string> value = 1 [(buf.validate.field).map.keys = {
-	//	   string: {
-	//	     min_len: 3
-	//	     max_len: 10
-	//	   }
-	//	 }];
+	//	  // The keys in the field `value` must follow the specified constraints.
+	//	  map<string, string> value = 1 [(buf.validate.field).map.keys = {
+	//	    string: {
+	//	      min_len: 3
+	//	      max_len: 10
+	//	    }
+	//	  }];
 	//	}
 	//
 	// ```
@@ -4996,13 +5022,13 @@ type MapRules struct {
 	// ```proto
 	//
 	//	message MyMap {
-	//	 // The values in the field `value` must follow the specified constraints.
-	//	 map<string, string> value = 1 [(buf.validate.field).map.values = {
-	//	   string: {
-	//	     min_len: 5
-	//	     max_len: 20
-	//	   }
-	//	 }];
+	//	  // The values in the field `value` must follow the specified constraints.
+	//	  map<string, string> value = 1 [(buf.validate.field).map.values = {
+	//	    string: {
+	//	      min_len: 5
+	//	      max_len: 20
+	//	    }
+	//	  }];
 	//	}
 	//
 	// ```
@@ -5082,7 +5108,7 @@ type AnyRules struct {
 	// ```proto
 	//
 	//	message MyAny {
-	//	 //  The `value` field must have a `type_url` equal to one of the specified values.
+	//	  //  The `value` field must have a `type_url` equal to one of the specified values.
 	//	  google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
 	//	}
 	//
@@ -5093,7 +5119,7 @@ type AnyRules struct {
 	// ```proto
 	//
 	//	message MyAny {
-	//	 // The field `value` must not have a `type_url` equal to any of the specified values.
+	//	  // The field `value` must not have a `type_url` equal to any of the specified values.
 	//	  google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
 	//	}
 	//
@@ -5160,7 +5186,7 @@ type DurationRules struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // value must equal 5s
+	//	  // value must equal 5s
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
 	//	}
 	//
@@ -5183,7 +5209,7 @@ type DurationRules struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // value must be in list [1s, 2s, 3s]
+	//	  // value must be in list [1s, 2s, 3s]
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
 	//	}
 	//
@@ -5197,7 +5223,7 @@ type DurationRules struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // value must not be in list [1s, 2s, 3s]
+	//	  // value must not be in list [1s, 2s, 3s]
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
 	//	}
 	//
@@ -5312,7 +5338,7 @@ type DurationRules_Lt struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // value must be less than 5s
+	//	  // value must be less than 5s
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
 	//	}
 	//
@@ -5328,7 +5354,7 @@ type DurationRules_Lte struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // value must be less than or equal to 10s
+	//	  // value must be less than or equal to 10s
 	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
 	//	}
 	//
@@ -5354,14 +5380,14 @@ type DurationRules_Gt struct {
 	// ```proto
 	//
 	//	message MyDuration {
-	//	 // duration must be greater than 5s [duration.gt]
-	//	 google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+	//	  // duration must be greater than 5s [duration.gt]
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
 	//
-	//	 // duration must be greater than 5s and less than 10s [duration.gt_lt]
-	//	 google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+	//	  // duration must be greater than 5s and less than 10s [duration.gt_lt]
+	//	  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
 	//
-	//	 // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-	//	 google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+	//	  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+	//	  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
 	//	}
 	//
 	// ```
@@ -5407,7 +5433,7 @@ type TimestampRules struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // value must equal 2023-05-03T10:00:00Z
+	//	  // value must equal 2023-05-03T10:00:00Z
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
 	//	}
 	//
@@ -5430,7 +5456,7 @@ type TimestampRules struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // value must be within 1 hour of now
+	//	  // value must be within 1 hour of now
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
 	//	}
 	//
@@ -5606,14 +5632,14 @@ type TimestampRules_Gt struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-	//	 google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+	//	  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+	//	  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
 	//
-	//	 // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-	//	 google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+	//	  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+	//	  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
 	//
-	//	 // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-	//	 google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+	//	  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+	//	  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
 	//	}
 	//
 	// ```
@@ -5630,14 +5656,14 @@ type TimestampRules_Gte struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-	//	 google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+	//	  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+	//	  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
 	//
-	//	 // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-	//	 google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+	//	  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+	//	  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
 	//
-	//	 // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-	//	 google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+	//	  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+	//	  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
 	//	}
 	//
 	// ```
@@ -5650,7 +5676,7 @@ type TimestampRules_GtNow struct {
 	// ```proto
 	//
 	//	message MyTimestamp {
-	//	 // value must be greater than now
+	//	  // value must be greater than now
 	//	  google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
 	//	}
 	//

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -283,9 +283,8 @@ type FieldConstraints struct {
 	// this field must be set. If required is set to true, the field value must
 	// not be empty; otherwise, an error message will be generated.
 	//
-	// Note that `required` does *not* validate that repeated fields are non-empty.
-	// If you'd like to validate that a `repeated` field is non-empty, use
-	// `repeated.min_items = 1`.
+	// Note that `required` validates that `repeated` fields are non-empty, that is
+	// setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
 	//
 	// ```proto
 	//
@@ -4852,6 +4851,8 @@ type RepeatedRules struct {
 
 	// `min_items` requires that this field must contain at least the specified
 	// minimum number of items.
+	//
+	// Note that `min_items = 1` is equivalent to setting a field as `required`.
 	//
 	// ```proto
 	//


### PR DESCRIPTION
This PR does a few things:

1. Add note about `repeated` fields being marked as `required`.

The original purpose of this PR. This adds the following note:

```
  // Note that `required` does *not* validate that repeated fields are non-empty.
  // If you'd like to validate that a `repeated` field is non-empty, use
  // `repeated.min_items = 1`.
```

2. Update indentation

This makes sure there is a space after every `//` and updates all the indentation within comments consistently. In some places, we had a space, in others we did not, this does the standard space.

3. Add some backticks around field names

We mostly use backticks around field names, but we don't consistently, this updates in a few obvious spots.

Future TODOs:

- Agree as a company on use of backticks. I could get behind them, I've seen other patterns as well, worth a short discussion.
- Agree as a company on whether to use Golang-style comments i.e. `Foo is a bar.` vs i.e. `A bar.`.