### PR TITLE
Fix broken pv-go link in docs

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -101,4 +101,4 @@ Then we could run the conformance tests with the following command:
 [harness-proto]: /proto/protovalidate-testing/buf/validate/conformance/harness/harness.proto
 [cases-proto]: /proto/protovalidate-testing/buf/validate/conformance/cases
 [suites]: /tools/protovalidate-conformance/internal/cases
-[pv-go]: https://github.com/bufbuild/protovalidate-go/internal/cmd/protovalidate-conformance-go
+[pv-go]: https://github.com/bufbuild/protovalidate-go/tree/main/internal/cmd/protovalidate-conformance-go


### PR DESCRIPTION
Link was leading to a 404 error page.