### PR TITLE
Fix typos in comments and documentation of `examples`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,5 +24,4 @@ To get started, checkout the following examples:
 - [`cel_conditional_operator.proto`](cel_conditional_operator.proto)
 - [`cel_field_presence.proto`](cel_field_presence.proto)
 
-The langugage specification can be found [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
-
+The language specification can be found [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md).

--- a/examples/cel_enum_comparision.proto
+++ b/examples/cel_enum_comparision.proto
@@ -26,7 +26,7 @@ message UploadFileRequest {
   CompressionScheme compression_scheme = 2 [(buf.validate.field).cel = {
     id: "compression_specified",
     message: "compression scheme must be specified",
-    // Validate that compression_schem is specified.
+    // Validate that compression_scheme is specified.
     // Note that `this`, as a enum, can be directly compared with an int.
     // In this case, 0 is the variant COMPRESSION_SCHEME_UNSPECIFIED from the
     // definition below.

--- a/examples/cel_map_all.proto
+++ b/examples/cel_map_all.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 import "buf/validate/validate.proto";
 
 message ShoppingCart {
-  // product_id_to_quantity maps from a product id to its quantiy in the shopping cart
+  // product_id_to_quantity maps from a product id to its quantity in the shopping cart
   map<uint64, uint32> product_id_to_quantity = 1;
   option (buf.validate.message).cel = {
     id: "quantity_positive",

--- a/examples/cel_map_exists.proto
+++ b/examples/cel_map_exists.proto
@@ -32,7 +32,7 @@ message CustomerReviews {
   map<fixed64, ProductReview> customer_id_to_review = 1;
   // highest_rating is the highest rating this product receives.
   float highest_rating = 2;
-  // This validates that there is at least one review from customer_id_to_reivew
+  // This validates that there is at least one review from customer_id_to_review
   // such that its rating is the same as highest_rating.
   option (buf.validate.message).cel = {
     id: "highest_rating_exists",

--- a/examples/cel_map_exists_one.proto
+++ b/examples/cel_map_exists_one.proto
@@ -23,7 +23,7 @@ message TeamRoles {
   option (buf.validate.message).cel = {
     id: "exactly_one_captain",
     message: "there must be exactly one captain",
-    // `exists_one` validates that exactly one key in the map satifies the predicate.
+    // `exists_one` validates that exactly one key in the map satisfies the predicate.
     // In this case, it validates that exactly one player in the team has the
     // captain role.
     expression: "this.name_to_role.exists_one(name, this.name_to_role[name] == 1)"

--- a/examples/cel_repeated_field_filter_and_count.proto
+++ b/examples/cel_repeated_field_filter_and_count.proto
@@ -23,7 +23,7 @@ message FiveTruthsThreeLies {
     message: "there must be exactly three lies",
     // `this.statement.filter` evaluates to a new list, whose elements are those
     // from the original one that satisfies the predicate. In this case, the filter
-    // evaluates to the list of statments that are true.
+    // evaluates to the list of statements that are true.
     // `size` evaluates to the length of the list, and we compare it to 3 to make
     // validate after filtering out the true statements, there are three false statements left.
     expression: "size(this.statement.filter(s, !s.is_truth)) == 3"

--- a/examples/cel_string_contains.proto
+++ b/examples/cel_string_contains.proto
@@ -25,7 +25,7 @@ message PublishArticleRequest {
   option (buf.validate.message).cel = {
     id: "article_contain_keyword",
     message: "article must contain all the keywords it is tagged with",
-    // For each keyword `kw`, valiate that it appears in the article.
+    // For each keyword `kw`, validate that it appears in the article.
     // `contains` checks whether a string contains another string.
     expression: "this.keyword.all(kw, this.article_content.contains(kw))"
   };

--- a/examples/cel_string_is_ip.proto
+++ b/examples/cel_string_is_ip.proto
@@ -26,10 +26,10 @@ message LocationForIpRequest {
     id: "valid_address",
     message: ".",
     // `some_string.isIp()` returns whether the string is a valid ip address.
-    // `isIp(4)` returns whehter a strign is an ipv4 address.
-    // `isIp(6)` returns whehter a strign is an ipv6 address.
+    // `isIp(4)` returns whether a string is an ipv4 address.
+    // `isIp(6)` returns whether a string is an ipv6 address.
     // In this case, it validates that field `ip_address` must be a valid ip
-    // adress, either ipv4 or ipv6.
+    // address, either ipv4 or ipv6.
     expression: "this.isIp()"
   }];
 }

--- a/examples/cel_string_match_pattern.proto
+++ b/examples/cel_string_match_pattern.proto
@@ -25,7 +25,7 @@ message UpdateUsernameRequest {
   // new_username is the username to update to.
   string new_username = 1 [(buf.validate.field).cel = {
     id: "username_format",
-    message: "username must be 3 - 16 characters long and only conatain letters and digits",
+    message: "username must be 3 - 16 characters long and only contain letters and digits",
     // `this.matches` match the string against a regex pattern, and evaluates to a bool.
     expression: "this.matches('^[A-Za-z0-9]{3,16}$')"
   }];

--- a/examples/cel_wrapper_type.proto
+++ b/examples/cel_wrapper_type.proto
@@ -36,7 +36,7 @@ message SearchStoreRequest {
   }];
   // category_id is the id of the category that the search results should be in.
   google.protobuf.UInt64Value category_id = 2 [(buf.validate.field).cel = {
-    id: "categorty_id_not_123",
+    id: "category_id_not_123",
     message: "category id should not be 123"
     // This validates that _if_ category_id is specified, it must not be 123.
     // This rule is only evaluated when this field is specified, because

--- a/examples/option_enum_allow_values.proto
+++ b/examples/option_enum_allow_values.proto
@@ -26,7 +26,7 @@ message SetOnlineStatusRequest {
   OnlineStatus new_status = 1 [(buf.validate.field).enum = {
     // `defined_only` validates that this enum value must be a defined value.
     // In this case, the enum's value must be one of 0, 1, 2, 5 and 10.
-    // Note that unspecifed value `ONLINE_STATUS_UNSPECIFIED = 0;` is considered defined.
+    // Note that unspecified value `ONLINE_STATUS_UNSPECIFIED = 0;` is considered defined.
     defined_only: true,
     // `in` validates that this enum must be a value from the list provided.
     // In this case, it validates this enum must be one of 1, 2, 5 and 10.

--- a/examples/option_field_presence.proto
+++ b/examples/option_field_presence.proto
@@ -23,9 +23,9 @@ service FridgeControlService {
 }
 
 message SetTemperatureRequest {
-  // temperature is the target temperature in degree celcius.
+  // temperature is the target temperature in degree Celsius.
   // Validate that the field is set. There is a difference between
-  // not setting the value and setting it to 0 degree celsius.
+  // not setting the value and setting it to 0 degree Celsius.
   google.protobuf.FloatValue temperature_celsius = 3 [(buf.validate.field).required = true];
 }
 

--- a/examples/option_field_skip_validation.proto
+++ b/examples/option_field_skip_validation.proto
@@ -26,7 +26,7 @@ message UpdateHealthInfoRequest {
   // `skipped` skips evaluating validation rules for a certain field. This
   // includes skipping validation rules defined within that message's definition
   // if the field is a message.
-  // In this case, when the validator validats a `UpdateHealthInfoRequest`
+  // In this case, when the validator validates a `UpdateHealthInfoRequest`
   // message, it will not validate field `health_info`. i.e. it will not validate
   // that health_info.height > 0 and health_info.weight > 0.
   HealthInfo health_info = 2 [(buf.validate.field).skipped = true];

--- a/examples/option_number_equal.proto
+++ b/examples/option_number_equal.proto
@@ -23,6 +23,6 @@ message Polygon {
   uint32 number_of_sides = 1 [(buf.validate.field).uint32.const = 3];
   // area is the area of the polygon
   // `gt` validates that the area greater than a particular value. In this
-  // case, it validaters that the area is positive.
+  // case, it validates that the area is positive.
   double area = 2 [(buf.validate.field).double.gt = 0.0];
 }

--- a/examples/option_number_finite_and_infinite.proto
+++ b/examples/option_number_finite_and_infinite.proto
@@ -33,7 +33,7 @@ message AddStarRequest {
     finite: true
   }];
   // mystery_index is how mysterious the star is.
-  // `gte = +inf` validates that the number must be greater than positve infinity.
+  // `gte = +inf` validates that the number must be greater than positive infinity.
   // This means mystery_index must be +inf.
   // protoc fails to compile this line but Buf compiles it successfully:
   // float mystery_index = 3 [(buf.validate.field).float.gte = +inf];

--- a/examples/option_string_match_pattern.proto
+++ b/examples/option_string_match_pattern.proto
@@ -39,7 +39,7 @@ message UserProfile {
     // `uri` validates that a string field must be an absolute uri, as defined by
     // [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3).
     //
-    // Or use `uri_ref` to validate that it must be a relative or aboslute URI, as
+    // Or use `uri_ref` to validate that it must be a relative or absolute URI, as
     // defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3).
     // (buf.validate.field).string.uri_ref = true,
     (buf.validate.field).string.uri = true,

--- a/examples/option_timestamp_range.proto
+++ b/examples/option_timestamp_range.proto
@@ -20,7 +20,7 @@ import "google/protobuf/timestamp.proto";
 message EventFromTheTwentiethCentury {
   // name is the name of the event
   string name = 1;
-  // description is the desciprition of the event
+  // description is the description of the event
   string description = 2;
   // timestamp is the timestamp when this event happened.
   google.protobuf.Timestamp timestamp = 3 [(buf.validate.field).timestamp = {


### PR DESCRIPTION
Committing changes to a few `proto` files located in the `/examples` folder, to mainly fix typos and spelling. 

This changes aims to make it easier for contributors to adopt these samples into their own project, and increase the confidence in the accuracy of the validation framework by signaling that a review process of the examples has taken place.