### PR TITLE
Disable PR comment for ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           breaking: true
           push: false
           archive: false
+          pr_comment: false
       - name: Buf generate
         run: |
           mkdir -p .tmp/bin


### PR DESCRIPTION
Disable PR comments for now until buf-action supports forks.