### PR TITLE
Format example files containing message options

### DIFF
--- a/examples/cel_bytes_concatenation.proto
+++ b/examples/cel_bytes_concatenation.proto
@@ -18,13 +18,14 @@ import "buf/validate/validate.proto";
 
 message CompactDocument {
   option (buf.validate.message).cel = {
-    id: "header_footer_size_limit",
-    message: "header and footer should be less than 500 bytes in total",
+    id: "header_footer_size_limit"
+    message: "header and footer should be less than 500 bytes in total"
     // the `+` operator concatenates two `bytes` together and `size` returns
     // the length of a `bytes`.
     // This validates that the combined size of header and footer should be < 500.
     expression: "size(this.header + this.footer) < 500"
   };
+
   bytes header = 1;
   bytes footer = 2;
 }

--- a/examples/cel_conditional_operator.proto
+++ b/examples/cel_conditional_operator.proto
@@ -18,7 +18,7 @@ import "buf/validate/validate.proto";
 
 message Triangle {
   option (buf.validate.message).cel = {
-    id: "triangle.distinct_points",
+    id: "triangle.distinct_points"
     // This is a nested ternary expression. If the expression evaluates to a non-empty
     // string, validation will fail with that string as the error message.
     // The expression below is a nested ternary expression.
@@ -26,15 +26,16 @@ message Triangle {
       "this.point_a == this.point_b ? 'point A and point B cannot be the same'"
       ": this.point_b == this.point_c ? 'point B and point C cannot be the same'"
       ": this.point_a == this.point_c ? 'point A and point C cannot be the same'"
-      ": ''",
+      ": ''"
   };
   option (buf.validate.message).cel = {
-    id: "triangle.non_linear_points",
-    message: "three points must not be on the same line",
+    id: "triangle.non_linear_points"
+    message: "three points must not be on the same line"
     expression:
       "(this.point_a.y - this.point_b.y) * (this.point_a.x - this.point_c.x)"
-      "!= (this.point_a.y - this.point_c.y) * (this.point_a.x - this.point_b.x)";
+      "!= (this.point_a.y - this.point_c.y) * (this.point_a.x - this.point_b.x)"
   };
+
   Point point_a = 1;
   Point point_b = 2;
   Point point_c = 3;

--- a/examples/cel_duration_arithmetic.proto
+++ b/examples/cel_duration_arithmetic.proto
@@ -19,8 +19,8 @@ import "google/protobuf/duration.proto";
 
 message IndirectFlight {
   option (buf.validate.message).cel = {
-    id: "total_length_limit",
-    message: "the entire trip should be less than 48 hours",
+    id: "total_length_limit"
+    message: "the entire trip should be less than 48 hours"
     expression:
       // This validates that the total duration of an indirect flight should be
       // less than 48 hours.
@@ -31,6 +31,7 @@ message IndirectFlight {
       // Durations can be compared with `<`, `<=`, `>=`, `>`, `==` and `!=`.
       "+ this.layover_duration < duration('48h')"
   };
+
   google.protobuf.Duration first_flight_duration = 1;
   google.protobuf.Duration layover_duration = 2;
   google.protobuf.Duration second_flight_duration = 3;

--- a/examples/cel_field_presence.proto
+++ b/examples/cel_field_presence.proto
@@ -25,13 +25,14 @@ service AddressService {
 message UpdateAddressInfoRequest {
   // If a secondary residence is set, the primary one must also be set.
   option (buf.validate.message).cel = {
-    id: "secondary_residence_depends_on_primary",
+    id: "secondary_residence_depends_on_primary"
     // `has(this.field)` evaluates to true if a field is present.
     expression:
       "has(this.new_secondary_residence) && !has(this.new_primary_residence)"
       "? 'cannot set a secondary residence without setting a primary one'"
       ": ''"
   };
+
   google.type.PostalAddress new_primary_residence = 1;
   google.type.PostalAddress new_secondary_residence = 2;
 }

--- a/examples/cel_field_presence_nested.proto
+++ b/examples/cel_field_presence_nested.proto
@@ -23,12 +23,13 @@ service ContactService {
 
 message CreateContactRequest {
   option (buf.validate.message).cel = {
-    id: "create_contact_with_first_name",
-    message: "the contact must have first name",
+    id: "create_contact_with_first_name"
+    message: "the contact must have first name"
     // This expression validates that all of `this.contact`, `this.contact.full_name`
     // and `this.contact.full_name.first_name` are set.
     expression: "has(this.contact.full_name.first_name)"
   };
+
   // contact is the contact to create.
   Contact contact = 1;
 }

--- a/examples/cel_field_selection.proto
+++ b/examples/cel_field_selection.proto
@@ -24,8 +24,8 @@ service ApartmentService {
 
 message SearchApartmentRequest {
   option (buf.validate.message).cel = {
-    id: "secondary_address_after_primary_address",
-    message: "the minimum number of bedrooms cannot be higher than the maximum number",
+    id: "secondary_address_after_primary_address"
+    message: "the minimum number of bedrooms cannot be higher than the maximum number"
     // In a message-level constraint, `this` refers to the message itself, the `SearchApartmentRequest`.
     // You can access a field with `this.field_name`.
     // The following expression is broken down into three string literals.
@@ -37,6 +37,7 @@ message SearchApartmentRequest {
       // If both the maximum and minimum number of bedrooms are specified, validate that minimum <= maximum.
       ": this.min_bedroom_count <= this.max_bedroom_count"
   };
+
   // only looking for apartments with at most this many bedrooms
   google.protobuf.UInt32Value max_bedroom_count = 1;
   // only looking for apartments with at least this many bedrooms

--- a/examples/cel_list_concatenation.proto
+++ b/examples/cel_list_concatenation.proto
@@ -17,16 +17,16 @@ syntax = "proto3";
 import "buf/validate/validate.proto";
 
 message BeverageMenu {
-  repeated string hot_beverages = 1;
-  repeated string cold_beverages = 2;
-  string daily_special = 3;
-
   option (buf.validate.message).cel = {
-    id: "daily_special_either_hot_or_cold",
-    message: "the daily special must be in either the hot menu or the cold menu",
+    id: "daily_special_either_hot_or_cold"
+    message: "the daily special must be in either the hot menu or the cold menu"
     // The `+` is loaded for lists (repeated fields) and it concatenates two lists.
     // In this case `this.hot_beverages` + `this.cold_beverages` evaluates to a list
     // containing beverages from both lists.
     expression: "this.daily_special in this.hot_beverages + this.cold_beverages"
   };
+
+  repeated string hot_beverages = 1;
+  repeated string cold_beverages = 2;
+  string daily_special = 3;
 }

--- a/examples/cel_map_all.proto
+++ b/examples/cel_map_all.proto
@@ -17,14 +17,15 @@ syntax = "proto3";
 import "buf/validate/validate.proto";
 
 message ShoppingCart {
-  // product_id_to_quantity maps from a product id to its quantity in the shopping cart
-  map<uint64, uint32> product_id_to_quantity = 1;
   option (buf.validate.message).cel = {
-    id: "quantity_positive",
-    message: "each product in the shopping cart must have positive quantity",
+    id: "quantity_positive"
+    message: "each product in the shopping cart must have positive quantity"
     // `all` checks whether a predicate holds true for all keys in a map. In this
     // case, each key of the map binds to a `pid` and the predicate is evaluated.
     // `this[pid]` looks up this product id in the map and evaluates to its amount.
     expression: "this.product_id_to_quantity.all(pid, this.product_id_to_quantity[pid] > 0)"
   };
+
+  // product_id_to_quantity maps from a product id to its quantity in the shopping cart
+  map<uint64, uint32> product_id_to_quantity = 1;
 }

--- a/examples/cel_map_exists.proto
+++ b/examples/cel_map_exists.proto
@@ -28,15 +28,11 @@ import "buf/validate/validate.proto";
 
 // CustomerReviews is customers' reviews for a product.
 message CustomerReviews {
-  // customer_id_to_review maps a customer id to a review.
-  map<fixed64, ProductReview> customer_id_to_review = 1;
-  // highest_rating is the highest rating this product receives.
-  float highest_rating = 2;
   // This validates that there is at least one review from customer_id_to_review
   // such that its rating is the same as highest_rating.
   option (buf.validate.message).cel = {
-    id: "highest_rating_exists",
-    message: "highest_rating must be the highest from reviews",
+    id: "highest_rating_exists"
+    message: "highest_rating must be the highest from reviews"
     expression:
       // `some_map.exists` validates that a predicate (condition) is true for some
       // key in this map. To validate that a predicate is true for some _value_ in
@@ -47,6 +43,11 @@ message CustomerReviews {
       "  this.customer_id_to_review[id].rating == this.highest_rating"
       ")"
   };
+
+  // customer_id_to_review maps a customer id to a review.
+  map<fixed64, ProductReview> customer_id_to_review = 1;
+  // highest_rating is the highest rating this product receives.
+  float highest_rating = 2;
 }
 
 message ProductReview {

--- a/examples/cel_map_exists_one.proto
+++ b/examples/cel_map_exists_one.proto
@@ -18,16 +18,17 @@ import "buf/validate/validate.proto";
 
 // TeamRoles has role information for each player.
 message TeamRoles {
-  // name_to_role maps from a team member's name to role.
-  map<string, TeamRole> name_to_role = 1;
   option (buf.validate.message).cel = {
-    id: "exactly_one_captain",
-    message: "there must be exactly one captain",
+    id: "exactly_one_captain"
+    message: "there must be exactly one captain"
     // `exists_one` validates that exactly one key in the map satisfies the predicate.
     // In this case, it validates that exactly one player in the team has the
     // captain role.
     expression: "this.name_to_role.exists_one(name, this.name_to_role[name] == 1)"
   };
+
+  // name_to_role maps from a team member's name to role.
+  map<string, TeamRole> name_to_role = 1;
 }
 
 enum TeamRole {

--- a/examples/cel_map_size.proto
+++ b/examples/cel_map_size.proto
@@ -18,13 +18,14 @@ import "buf/validate/validate.proto";
 
 // PenInventory is the pen inventory.
 message PenInventory {
-  // color_to_count maps from a color id to the amount of pens of the color.
-  map<uint32, uint32> color_to_count = 1;
   option (buf.validate.message).cel = {
-    id: "at_most_30_colors",
-    message: "there must not be more than 30 colors",
+    id: "at_most_30_colors"
+    message: "there must not be more than 30 colors"
     // `size(some_map)` returns the number of keys in this map.
     // In this case, it validates that the map has at most 30 keys.
     expression: "size(this.color_to_count) <= 30"
   };
+
+  // color_to_count maps from a color id to the amount of pens of the color.
+  map<uint32, uint32> color_to_count = 1;
 }

--- a/examples/cel_repeated_field_all.proto
+++ b/examples/cel_repeated_field_all.proto
@@ -26,11 +26,12 @@ message CreateGroupChatRequest {
   // Note: to treat a repeated field as a list in cel, access it from the message
   // option as opposed to the field option.
   option (buf.validate.message).cel = {
-    id: "group_chat_member_must_be_verified",
-    message: "all group chat members must be verified users",
+    id: "group_chat_member_must_be_verified"
+    message: "all group chat members must be verified users"
     // `m.is_verified` must be true for all `m` in `this.member`
     expression: "this.member.all(m, m.is_verified)"
   };
+
   // member is the members of the group chat
   repeated ChatAppUser member = 1;
 }

--- a/examples/cel_repeated_field_exists_one.proto
+++ b/examples/cel_repeated_field_exists_one.proto
@@ -20,18 +20,18 @@ import "buf/validate/validate.proto";
 message TeamRoster {
   // one and only one players on the team is the captain.
   option (buf.validate.message).cel = {
-    id: "captain_exists",
-    message: "captain must be among the list of players",
+    id: "captain_exists"
+    message: "captain must be among the list of players"
     // `exists_one` checks that one and only one item in the list satisfies
     // the predicate, which is `p.name == this.captain_name` in this case.
     expression: "this.players.exists_one(p, p.name == this.captain_name)"
   };
 
-  repeated Player players = 1;
-  string captain_name = 2;
-
   message Player {
     string name = 1;
     uint32 jersy_number = 2;
   }
+
+  repeated Player players = 1;
+  string captain_name = 2;
 }

--- a/examples/cel_repeated_field_filter_and_count.proto
+++ b/examples/cel_repeated_field_filter_and_count.proto
@@ -19,8 +19,8 @@ import "buf/validate/validate.proto";
 // FiveTruthsThreeLies is a new game based on the classic Two Truths One Lie.
 message FiveTruthsThreeLies {
   option (buf.validate.message).cel = {
-    id: "exactly_three_lies",
-    message: "there must be exactly three lies",
+    id: "exactly_three_lies"
+    message: "there must be exactly three lies"
     // `this.statement.filter` evaluates to a new list, whose elements are those
     // from the original one that satisfies the predicate. In this case, the filter
     // evaluates to the list of statements that are true.
@@ -29,11 +29,12 @@ message FiveTruthsThreeLies {
     expression: "size(this.statement.filter(s, !s.is_truth)) == 3"
   };
   option (buf.validate.message).cel = {
-    id: "exactly_five_truths",
-    message: "there must be exactly five truths",
+    id: "exactly_five_truths"
+    message: "there must be exactly five truths"
     // Similarly, validate that exactly five truths
     expression: "size(this.statement.filter(s, s.is_truth)) == 5"
   };
+
   repeated TruthOrLieStatement statement = 1;
 }
 

--- a/examples/cel_repeated_field_transform_and_unique.proto
+++ b/examples/cel_repeated_field_transform_and_unique.proto
@@ -29,7 +29,6 @@ message Book {
     // In this case, the expression validates that genres are unique.
     expression: "this.unique()"
   }];
-
   repeated Author authors = 2 [(buf.validate.field).cel = {
     id: "book_unique_authors"
     message: "a name cannot appear twice in authors"

--- a/examples/cel_string_contains.proto
+++ b/examples/cel_string_contains.proto
@@ -23,12 +23,13 @@ service ArticleService {
 
 message PublishArticleRequest {
   option (buf.validate.message).cel = {
-    id: "article_contain_keyword",
-    message: "article must contain all the keywords it is tagged with",
+    id: "article_contain_keyword"
+    message: "article must contain all the keywords it is tagged with"
     // For each keyword `kw`, validate that it appears in the article.
     // `contains` checks whether a string contains another string.
     expression: "this.keyword.all(kw, this.article_content.contains(kw))"
   };
+
   string article_content = 1;
   // keyword is the keyword that this article is associated with.
   repeated string keyword = 2;

--- a/examples/cel_timestamp_plus_duration.proto
+++ b/examples/cel_timestamp_plus_duration.proto
@@ -25,12 +25,13 @@ service FlightInfoService {
 
 message UpdateFlightInfoRequest {
   option (buf.validate.message).cel = {
-    id: "correct_duration",
-    message: "duration must be the period of time between departure and arrival",
+    id: "correct_duration"
+    message: "duration must be the period of time between departure and arrival"
     // Adding a timestamp and a duration evaluates to a new timestamp.
     // Two timestamps can be compared with `==`, `!=`, `<`, `<=`, `>` and `>=`.
     expression: "this.new_departure_time + this.new_duration  == this.new_arrival_time"
   };
+
   uint64 flight_id = 1;
   // departure_time is the departure time.
   google.protobuf.Timestamp new_departure_time = 2;

--- a/examples/cel_wrapper_type.proto
+++ b/examples/cel_wrapper_type.proto
@@ -23,56 +23,8 @@ service StoreService {
 }
 
 message SearchStoreRequest {
-  // term is the search term
-  google.protobuf.StringValue term = 1 [(buf.validate.field).cel = {
-    id: "search_term_length",
-    message: "search term must be not exceed 100 characters",
-    // This validates that _if_ term is specified, it must be shorter than 100
-    // characters long.
-    // This rule is only evaluated when this field is specified, because
-    // google.protobuf.StringValue is a message type, and CEL rules are evaluated
-    // only when the message field is present.
-    expression: "size(this) <= 100"
-  }];
-  // category_id is the id of the category that the search results should be in.
-  google.protobuf.UInt64Value category_id = 2 [(buf.validate.field).cel = {
-    id: "category_id_not_123",
-    message: "category id should not be 123"
-    // This validates that _if_ category_id is specified, it must not be 123.
-    // This rule is only evaluated when this field is specified, because
-    // google.protobuf.UInt64Value is a message type, and CEL rules are evaluated
-    // only when the message field is present.
-    expression: "this != uint(123)"
-  }];
-  // in_stock is whether the search results should be in stock.
-  // Setting this field to false means only searching for out-of-stock items.
-  // Leaving this field unset searches for items both out of stock and in stock.
-  google.protobuf.BoolValue in_stock = 3;
-  // min_price is the minimum price that the search results should have.
-  google.protobuf.FloatValue min_price = 4 [(buf.validate.field).cel = {
-    id: "min_price_finite",
-    message: "min_price_must_be_positive",
-    // This validates that _if_ min_price is specified, it must be greater than 0.
-    // This rule is only evaluated when this field is specified, because
-    // google.protobuf.FloatValue is a message type, and CEL rules are evaluated
-    // only when the message field is present.
-    expression: "this > 0"
-  }];
-  // max_price is the maximum price that the search results should have.
-  google.protobuf.DoubleValue max_price = 5 [(buf.validate.field).cel = {
-    id: "max_price_finite",
-    message: "maximum price must be finite",
-    // This validates that _if_ max_price is specified, it must not be 123.
-    // This rule is only evaluated when this field is specified, because
-    // google.protobuf.DoubleValue is a message type, and CEL rules are evaluated
-    // only when the message field is present.
-    expression: "!this.isInf()"
-  }];
-  // quantity_available is the minimum quantity available of the search results.
-  google.protobuf.UInt32Value quantity_available = 6;
-
   option (buf.validate.message).cel = {
-    id: "positive_quantity_but_out_of_stock",
+    id: "positive_quantity_but_out_of_stock"
     // this checks that if you are searching for items out of stock, you cannot
     // specify a positive quantity available.
     expression:
@@ -89,6 +41,54 @@ message SearchStoreRequest {
       ": this.quantity_available > 0 ? 'cannot search for a positive quantity when filtering for out-of-stock items'"
       ": ''"
   };
+
+  // term is the search term
+  google.protobuf.StringValue term = 1 [(buf.validate.field).cel = {
+    id: "search_term_length"
+    message: "search term must be not exceed 100 characters"
+    // This validates that _if_ term is specified, it must be shorter than 100
+    // characters long.
+    // This rule is only evaluated when this field is specified, because
+    // google.protobuf.StringValue is a message type, and CEL rules are evaluated
+    // only when the message field is present.
+    expression: "size(this) <= 100"
+  }];
+  // category_id is the id of the category that the search results should be in.
+  google.protobuf.UInt64Value category_id = 2 [(buf.validate.field).cel = {
+    id: "category_id_not_123"
+    message: "category id should not be 123"
+    // This validates that _if_ category_id is specified, it must not be 123.
+    // This rule is only evaluated when this field is specified, because
+    // google.protobuf.UInt64Value is a message type, and CEL rules are evaluated
+    // only when the message field is present.
+    expression: "this != uint(123)"
+  }];
+  // in_stock is whether the search results should be in stock.
+  // Setting this field to false means only searching for out-of-stock items.
+  // Leaving this field unset searches for items both out of stock and in stock.
+  google.protobuf.BoolValue in_stock = 3;
+  // min_price is the minimum price that the search results should have.
+  google.protobuf.FloatValue min_price = 4 [(buf.validate.field).cel = {
+    id: "min_price_finite"
+    message: "min_price_must_be_positive"
+    // This validates that _if_ min_price is specified, it must be greater than 0.
+    // This rule is only evaluated when this field is specified, because
+    // google.protobuf.FloatValue is a message type, and CEL rules are evaluated
+    // only when the message field is present.
+    expression: "this > 0"
+  }];
+  // max_price is the maximum price that the search results should have.
+  google.protobuf.DoubleValue max_price = 5 [(buf.validate.field).cel = {
+    id: "max_price_finite"
+    message: "maximum price must be finite"
+    // This validates that _if_ max_price is specified, it must not be 123.
+    // This rule is only evaluated when this field is specified, because
+    // google.protobuf.DoubleValue is a message type, and CEL rules are evaluated
+    // only when the message field is present.
+    expression: "!this.isInf()"
+  }];
+  // quantity_available is the minimum quantity available of the search results.
+  google.protobuf.UInt32Value quantity_available = 6;
 }
 
 message SearchStoreResponse {

--- a/examples/option_message_disable_validation.proto
+++ b/examples/option_message_disable_validation.proto
@@ -22,6 +22,7 @@ message DebugLog {
   // In this case, validation rules defined within `Payload`'s definition will
   // not be evaluated for `DebugLog.payload`.
   option (buf.validate.message).disabled = true;
+
   // payload is the payload.
   Payload payload = 1;
   // create_time is when the log is created.


### PR DESCRIPTION
If a message in an example file has message options, they are moved to the top of the message, and an empty line is added between message options and fields.

A lot of these changes happen because of auto formatting. Will do a follow-up that runs `buf format -w examples` for consistency within `examples`.