### PR TITLE
Format example proto files

### DIFF
--- a/examples/cel_assert_value_is_in_a_list.proto
+++ b/examples/cel_assert_value_is_in_a_list.proto
@@ -26,12 +26,12 @@ message IsDivisibleRequest {
   int32 dividend = 1;
   // divisor is the divisor in the division.
   int32 divisor = 2 [(buf.validate.field).cel = {
-    id: "divisor_must_be_a_small_prime",
-    message: "the divisor must be one of 2, 3 and 5",
+    id: "divisor_must_be_a_small_prime"
+    message: "the divisor must be one of 2, 3 and 5"
     // `in` evaluates list membership. The expression evaluates to
     // true when the value is in the list.
     // Validates that divisor must be one of 2, 3 and 5.
-    expression: "this in [2, 3, 5]",
+    expression: "this in [2, 3, 5]"
     // Similarly, you can assert that it's not in a list with `!(this in [2, 3, 5])`.
   }];
 }

--- a/examples/cel_bytes_contains.proto
+++ b/examples/cel_bytes_contains.proto
@@ -20,8 +20,8 @@ import "buf/validate/validate.proto";
 message Application {
   // binary is the application's binary
   bytes binary = 1 [(buf.validate.field).cel = {
-    id: "without_malicious_code",
-    message: "binary should not contain malicious code",
+    id: "without_malicious_code"
+    message: "binary should not contain malicious code"
     // `contains` returns if the receiver `bytes` contains the argument `bytes`.
     // This validates that the application binary should not contain bytes for
     // `'malicious code'`.

--- a/examples/cel_bytes_starts_with_ends_with.proto
+++ b/examples/cel_bytes_starts_with_ends_with.proto
@@ -18,7 +18,7 @@ import "buf/validate/validate.proto";
 
 message ScriptFile {
   bytes content = 1 [(buf.validate.field).cel = {
-    id: "script_start_with_shabang_end_with_line_feed",
+    id: "script_start_with_shabang_end_with_line_feed"
     expression:
       // this is a ternary expression in the form of a ? b : c, if the the
       // script file doesn't start with '#!', the expression evaluates to the

--- a/examples/cel_duration_from_string.proto
+++ b/examples/cel_duration_from_string.proto
@@ -24,8 +24,8 @@ service TimerService {
 
 message StartTimerRequest {
   google.protobuf.Duration duration = 1 [(buf.validate.field).cel = {
-    id: "maximum_duration",
-    message: "timer duration must be shorter than a day",
+    id: "maximum_duration"
+    message: "timer duration must be shorter than a day"
     // You can create a duration from a string literal in the form of `1m30s`,
     // where each number is has a unit suffix. The suffix supported are "h", "m",
     // "s", "ms", "us" and "ns".

--- a/examples/cel_enum_comparison.proto
+++ b/examples/cel_enum_comparison.proto
@@ -24,8 +24,8 @@ service FileService {
 message UploadFileRequest {
   bytes content = 1;
   CompressionScheme compression_scheme = 2 [(buf.validate.field).cel = {
-    id: "compression_specified",
-    message: "compression scheme must be specified",
+    id: "compression_specified"
+    message: "compression scheme must be specified"
     // Validate that compression_scheme is specified.
     // Note that `this`, as a enum, can be directly compared with an int.
     // In this case, 0 is the variant COMPRESSION_SCHEME_UNSPECIFIED from the

--- a/examples/cel_field_access.proto
+++ b/examples/cel_field_access.proto
@@ -26,11 +26,11 @@ message PlaceWholeSaleOrderRequest {
   uint64 item_id = 1;
   // quantity is the quantity of the item to purchase.
   uint32 quantity = 2 [(buf.validate.field).cel = {
-    id: "minimum_whole_sale_quantity",
-    message: "order quantity must be 100 or greater",
+    id: "minimum_whole_sale_quantity"
+    message: "order quantity must be 100 or greater"
     // `this` refers to this field and the expression evaluates to a boolean result.
     // If the result is false, validation will fail with the above error message.
-    expression: "this >= 100",
+    expression: "this >= 100"
   }];
 }
 

--- a/examples/cel_field_map.proto
+++ b/examples/cel_field_map.proto
@@ -21,20 +21,20 @@ message IPAddressMapping {
     keys: {
       cel: [
         {
-          id: "ip_prefix",
-          message: "key must be IPv4 prefix",
-          expression: "this.isIpPrefix(4, true)",
+          id: "ip_prefix"
+          message: "key must be IPv4 prefix"
+          expression: "this.isIpPrefix(4, true)"
         }
-      ],
-    },
+      ]
+    }
     values: {
       cel: [
         {
-          id: "ip_address",
-          message: "value must be IPv4 address",
-          expression: "this.isIpPrefix(4, true)",
+          id: "ip_address"
+          message: "value must be IPv4 address"
+          expression: "this.isIpPrefix(4, true)"
         }
-      ],
-    },
+      ]
+    }
   }];
-};
+}

--- a/examples/cel_field_mask.proto
+++ b/examples/cel_field_mask.proto
@@ -28,12 +28,12 @@ message UpdateSongRequest {
   Song song = 1;
   // field_mask masks the fields to update.
   google.protobuf.FieldMask field_mask = 2 [(buf.validate.field).cel = {
-    id: "valid_field_mask",
-    message: "a field mask path must be one of name, duration and artist.name",
+    id: "valid_field_mask"
+    message: "a field mask path must be one of name, duration and artist.name"
     // `some_list.all()` validates that a predicate is true for all elements
     // from that list.
     // In this case, `this.paths` is the field paths from.
-    expression: "this.paths.all(path, path in ['name', 'duration', 'artist.name'])",
+    expression: "this.paths.all(path, path in ['name', 'duration', 'artist.name'])"
   }];
 }
 

--- a/examples/cel_field_repeated.proto
+++ b/examples/cel_field_repeated.proto
@@ -18,15 +18,15 @@ import "buf/validate/validate.proto";
 
 message IPAllowlist {
   repeated string allow_cidr = 1 [(buf.validate.field).repeated = {
-    min_items: 1,
+    min_items: 1
     items: {
       cel: [
         {
-          id: "ip_prefix",
-          message: "value must be IPv4 prefix",
-          expression: "this.isIpPrefix(4, true)",
+          id: "ip_prefix"
+          message: "value must be IPv4 prefix"
+          expression: "this.isIpPrefix(4, true)"
         }
-      ],
-    },
+      ]
+    }
   }];
 }

--- a/examples/cel_infinity.proto
+++ b/examples/cel_infinity.proto
@@ -23,8 +23,8 @@ service BalanceService {
 
 message SetBalanceRequest {
   double new_balance = 1 [(buf.validate.field).cel = {
-    id: "finite_balance",
-    message: "balance should be finite",
+    id: "finite_balance"
+    message: "balance should be finite"
     // `isInf()` works on float and double, and returns true if the value is
     // infinity.
     // This validates that the new balance is finite.

--- a/examples/cel_number_arithmetic.proto
+++ b/examples/cel_number_arithmetic.proto
@@ -18,14 +18,14 @@ import "buf/validate/validate.proto";
 
 message FiveDigitPrimeLookalike {
   int32 value = 1 [(buf.validate.field).cel = {
-    id: "prime_lookalike",
-    message: "value must have 5 digits and look like a prime",
+    id: "prime_lookalike"
+    message: "value must have 5 digits and look like a prime"
     // Arithmetic operators include `+`, `-`, `*`, `/`, `%`.
     expression:
       "this % 2 != 0"
       "&& this % 3 != 0"
       "&& this % 5 != 0"
       "&& (this - 10000) * (this - 99999) <= 0"
-      "&& -this != 77777",
+      "&& -this != 77777"
   }];
 }

--- a/examples/cel_string_concatenation.proto
+++ b/examples/cel_string_concatenation.proto
@@ -22,7 +22,7 @@ service NewsLetterService {
 
 message JoinNewsLetterRequest {
   string email = 1 [(buf.validate.field).cel = {
-    id: "join_news_letter_request_valid_email",
+    id: "join_news_letter_request_valid_email"
     expression:
       "this.isEmail() ? ''"
       // The `+` operator is overloaded for strings and concatenates two strings.

--- a/examples/cel_string_is_email.proto
+++ b/examples/cel_string_is_email.proto
@@ -22,8 +22,8 @@ service MailingListService {
 
 message AddEmailToMailingListRequest {
   string email = 1 [(buf.validate.field).cel = {
-    id: "valid_email",
-    message: "email must be a valid email",
+    id: "valid_email"
+    message: "email must be a valid email"
     expression: "this.isEmail()"
   }];
 }

--- a/examples/cel_string_is_hostname.proto
+++ b/examples/cel_string_is_hostname.proto
@@ -19,8 +19,8 @@ import "buf/validate/validate.proto";
 message DeviceInfo {
   // hostname is the device's hostname on the network.
   string hostname = 1 [(buf.validate.field).cel = {
-    id: "device_info_valid_hostname",
-    message: "hostname must be valid",
+    id: "device_info_valid_hostname"
+    message: "hostname must be valid"
     // this validates that field `hostname` is a valid hostname.
     expression: "this.isHostname()"
   }];

--- a/examples/cel_string_is_ip.proto
+++ b/examples/cel_string_is_ip.proto
@@ -23,8 +23,8 @@ service LocationService {
 
 message LocationForIpRequest {
   string ip_address = 1 [(buf.validate.field).cel = {
-    id: "valid_address",
-    message: ".",
+    id: "valid_address"
+    message: "."
     // `some_string.isIp()` returns whether the string is a valid ip address.
     // `isIp(4)` returns whether a string is an ipv4 address.
     // `isIp(6)` returns whether a string is an ipv6 address.
@@ -40,8 +40,8 @@ message LocationForIpResponse {
 
 message LocationForIpPrefixRequest {
   string ip_prefix = 1 [(buf.validate.field).cel = {
-    id: "valid_prefix",
-    message: ".",
+    id: "valid_prefix"
+    message: "."
     // `some_string.isIpPrefix()` returns whether the string is a valid ip with prefix length.
     // `isIpPrefix(4)` returns whether a string is an ipv4 with prefix length.
     // `isIpPrefix(6)` returns whether a string is an ipv6 with prefix length.

--- a/examples/cel_string_is_uri.proto
+++ b/examples/cel_string_is_uri.proto
@@ -22,8 +22,8 @@ service ResourceService {
 
 message UploadResourceRequest {
   string uri = 1 [(buf.validate.field).cel = {
-    id: "valid_uri",
-    message: "uri must be a valid URI",
+    id: "valid_uri"
+    message: "uri must be a valid URI"
     // `isUri` validates that a string is an absolute URI.
     // This expression validates that the uri field is an absolute URI.
     // Note: to allow relative URI, use `isUriRef`.

--- a/examples/cel_string_match_pattern.proto
+++ b/examples/cel_string_match_pattern.proto
@@ -24,8 +24,8 @@ service UsernameService {
 message UpdateUsernameRequest {
   // new_username is the username to update to.
   string new_username = 1 [(buf.validate.field).cel = {
-    id: "username_format",
-    message: "username must be 3 - 16 characters long and only contain letters and digits",
+    id: "username_format"
+    message: "username must be 3 - 16 characters long and only contain letters and digits"
     // `this.matches` match the string against a regex pattern, and evaluates to a bool.
     expression: "this.matches('^[A-Za-z0-9]{3,16}$')"
   }];

--- a/examples/cel_string_starts_with_ends_with.proto
+++ b/examples/cel_string_starts_with_ends_with.proto
@@ -26,8 +26,8 @@ message AnswerJeopardyQuestionRequest {
   uint64 question_id = 1;
   // answer is an answer in the form of a question, such as "What is xyz?" and "Who is xyz?".
   string answer = 2 [(buf.validate.field).cel = {
-    id: "correct_answer_format",
-    message: "answer must start with 'wh' and end with '?'",
+    id: "correct_answer_format"
+    message: "answer must start with 'wh' and end with '?'"
     // `startsWith` evaluates to true when the string operand starts with the prefix argument.
     // `endsWith` evaluates to true when the string operand ends with the suffix argument.
     expression: "this.startsWith('wh') && this.endsWith('?')"

--- a/examples/cel_timestamp_comparison.proto
+++ b/examples/cel_timestamp_comparison.proto
@@ -19,8 +19,8 @@ import "google/protobuf/timestamp.proto";
 
 message EventFromTheNineteenthCentury {
   google.protobuf.Timestamp time = 1 [(buf.validate.field).cel = {
-    id: "timestamp_in_the_1800s",
-    message: "the event must be from the nineteenth century",
+    id: "timestamp_in_the_1800s"
+    message: "the event must be from the nineteenth century"
     expression:
       // `timestamp()` converts a string to a timestamp according to [rtf3339]
       // (https://datatracker.ietf.org/doc/html/rfc3339#section-5.8).

--- a/examples/cel_timestamp_get_attribute.proto
+++ b/examples/cel_timestamp_get_attribute.proto
@@ -25,8 +25,8 @@ service HaircutAppointmentService {
 message BookHaircutAppointmentRequest {
   // appointment_time is the time of the appoint.
   google.protobuf.Timestamp appointment_time = 1 [(buf.validate.field).cel = {
-    id: "not_open_on_monday",
-    message: "the barbershop is closed on Monday",
+    id: "not_open_on_monday"
+    message: "the barbershop is closed on Monday"
     // `getDayOfWeek(<time zone string>)` gets day of week from the date with
     // timezone.
     // The result is an int, where 0 means Sunday, 1 means Monday and so on.

--- a/examples/cel_timestamp_subtraction.proto
+++ b/examples/cel_timestamp_subtraction.proto
@@ -24,8 +24,8 @@ service ReservationService {
 
 message BookReservationRequest {
   google.protobuf.Timestamp start_time = 1 [(buf.validate.field).cel = {
-    id: "book_24_hrs_ahead",
-    message: "must book at least 24 hours ahead",
+    id: "book_24_hrs_ahead"
+    message: "must book at least 24 hours ahead"
     // `now` evaluates to a timestamp at the current time.
     // Subtracting two timestamps evaluates to a duration. In this case,
     // `this - now` evaluates to the time between now and time of the

--- a/examples/cel_type_conversion.proto
+++ b/examples/cel_type_conversion.proto
@@ -18,7 +18,7 @@ import "buf/validate/validate.proto";
 
 message Sound {
   uint32 frequency_hz = 1 [(buf.validate.field).cel = {
-    id: "frequency_in_the_audible_range",
+    id: "frequency_in_the_audible_range"
     expression:
       // `string()` converts an `uint` (and other primitive types) to a `string`.
       // In this case, the frequency is first converted to a string before being

--- a/examples/cel_value.proto
+++ b/examples/cel_value.proto
@@ -25,7 +25,7 @@ service DataStoreService {
 message WriteKeyValuePairRequest {
   // key is the key.
   google.protobuf.Value key = 1 [(buf.validate.field).cel = {
-    id: "write_key_value_pair_request_valid_key_type",
+    id: "write_key_value_pair_request_valid_key_type"
     message: "key must be one of int, uint, double, bool and string"
     expression: "type(this) in [int, uint, double, bool, string]"
   }];

--- a/examples/option_bytes_ban_values.proto
+++ b/examples/option_bytes_ban_values.proto
@@ -27,7 +27,7 @@ message UpdatePasswordRequest {
   // new_password is the new password.
   bytes new_password = 2 [(buf.validate.field).bytes = {
     // `min_len` validates that the password is at least 8 bytes
-    min_len: 8,
+    min_len: 8
     // `not_in` validates that the new password is not any password in the list:
     not_in: [
       "12345678",

--- a/examples/option_duration_equal.proto
+++ b/examples/option_duration_equal.proto
@@ -23,7 +23,7 @@ message ExpiredPacket {
     // `const` validates that a duration must be equal to this duration.
     // In this case, `time_to_live` must equal to 0.
     const: {
-      seconds: 0,
+      seconds: 0
       nanos: 0
     }
   }];

--- a/examples/option_duration_range.proto
+++ b/examples/option_duration_range.proto
@@ -35,7 +35,7 @@ message UploadSoundTrackRequest {
       gt: {
         seconds: 1
         nanos: 100000000
-      },
+      }
       // Validates that duration is less than or equal to 10 hours.
       lte: {seconds: 36000}
     }

--- a/examples/option_enum_allow_values.proto
+++ b/examples/option_enum_allow_values.proto
@@ -27,7 +27,7 @@ message SetOnlineStatusRequest {
     // `defined_only` validates that this enum value must be a defined value.
     // In this case, the enum's value must be one of 0, 1, 2, 5 and 10.
     // Note that unspecified value `ONLINE_STATUS_UNSPECIFIED = 0;` is considered defined.
-    defined_only: true,
+    defined_only: true
     // `in` validates that this enum must be a value from the list provided.
     // In this case, it validates this enum must be one of 1, 2, 5 and 10.
     in: [

--- a/examples/option_map.proto
+++ b/examples/option_map.proto
@@ -26,10 +26,10 @@ message Movie {
   map<string, string> played_by = 3 [(buf.validate.field).map = {
     // `min_pairs` validates that a map must have at least this many key-value pairs.
     // The map must include at least 1 character.
-    min_pairs: 1,
+    min_pairs: 1
     // `max_pairs` validates that a map must have at most this many key-value pairs.
     // The map must include at most 30 character.
-    max_pairs: 30,
+    max_pairs: 30
     // `keys` validates on the keys of a map.
     keys: {
       string: {
@@ -38,7 +38,7 @@ message Movie {
         min_len: 3
         max_len: 24
       }
-    },
+    }
     // `values` validates on the values of a map.
     values: {
       string: {
@@ -47,6 +47,6 @@ message Movie {
         min_len: 1
         max_len: 50
       }
-    },
+    }
   }];
 }

--- a/examples/option_number_allow_values.proto
+++ b/examples/option_number_allow_values.proto
@@ -24,7 +24,7 @@ service CarService {
 message SearchCarRequest {
   optional fixed32 number_of_seats = 1 [(buf.validate.field) = {
     // `ignore_empty` skips validation if the field isn't set.
-    ignore_empty: true,
+    ignore_empty: true
     fixed32: {
       // `in` requires that the value must be one of the specified values.
       // In this case, it validates that the number of seats is either 5 or 7.

--- a/examples/option_number_finite_and_infinite.proto
+++ b/examples/option_number_finite_and_infinite.proto
@@ -27,7 +27,7 @@ message AddStarRequest {
   // distance_ly is its distance from the Sun in light years.
   double distance_ly = 2 [(buf.validate.field).double = {
     // `gt` validates that the distance is positive.
-    gt: 0,
+    gt: 0
     // `finite` validates a double or float is not infinity.
     // In this case, it validates that the distance is not positive infinity.
     finite: true

--- a/examples/option_number_range.proto
+++ b/examples/option_number_range.proto
@@ -28,7 +28,7 @@ message CreateReviewRequest {
   string comment = 2;
   uint32 rating = 3 [(buf.validate.field).uint32 = {
     // validates a rating is greater than 0
-    gt: 0,
+    gt: 0
     // validates a rating is at most 10
     lte: 10
   }];
@@ -46,7 +46,7 @@ message AggregatedReview {
   // average_rating is the average of individual ratings
   float average_rating = 2 [(buf.validate.field).float = {
     // validates the average rating is at least 1.0
-    gte: 1.0,
+    gte: 1.0
     // validates the average rating is at most 10.0
     lte: 10.0
   }];

--- a/examples/option_repeated.proto
+++ b/examples/option_repeated.proto
@@ -25,17 +25,17 @@ message UpdateWaitlistRequest {
   // name is the names of people on the waitlist
   repeated string name = 1 [(buf.validate.field).repeated = {
     // Validate that no name can be in the list twice.
-    unique: true,
+    unique: true
     // At most 500 people can be on the waitlist. A lower bound can be set
     // similarly with `min_items`.
-    max_items: 500,
+    max_items: 500
     // `items` validate each value in this `repeated` field.
     items: {
       // `string` has string-specific rules for each value in the `repeated` field.
       // The set of rules allowed here is the same as that of a string field.
       string: {
         // Each name must not be empty
-        min_len: 1,
+        min_len: 1
         // Each name can contain at most 30 characters.
         max_len: 30
       }

--- a/examples/option_string_contains.proto
+++ b/examples/option_string_contains.proto
@@ -21,7 +21,7 @@ message GoodNews {
   string content = 1 [(buf.validate.field).string = {
     // `contains` validates that a string field contains this string.
     // In this example, it validates that content contains `up`.
-    contains: "up",
+    contains: "up"
     // `not_contains` validates that a string field doesn't contain this string.
     // In this example, it validates that content doesn't contain `down`.
     not_contains: "down"

--- a/examples/option_string_is_http_header.proto
+++ b/examples/option_string_is_http_header.proto
@@ -19,11 +19,11 @@ import "buf/validate/validate.proto";
 message HttpHeader {
   string name = 1 [(buf.validate.field).string = {
     // This validates that name is a valid http header name.
-    well_known_regex: KNOWN_REGEX_HTTP_HEADER_NAME,
+    well_known_regex: KNOWN_REGEX_HTTP_HEADER_NAME
   }];
   string value = 2 [(buf.validate.field).string = {
     // This validates that value is a valid http header value.
-    well_known_regex: KNOWN_REGEX_HTTP_HEADER_VALUE,
+    well_known_regex: KNOWN_REGEX_HTTP_HEADER_VALUE
     // `strict` applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
     // enable strict header validation. By default this value is true and
     // validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3).

--- a/examples/option_string_len.proto
+++ b/examples/option_string_len.proto
@@ -19,15 +19,15 @@ import "buf/validate/validate.proto";
 message User {
   string username = 1 [(buf.validate.field).string = {
     // `min_len` validates that username must have at least 3 characters.
-    min_len: 3;
+    min_len: 3
     // `max_len` validates that username must have at most 16 characters.
-    max_len: 16;
+    max_len: 16
   }];
   string description = 2 [(buf.validate.field).string = {
     // `min_bytes` specifies that a string field must have a least this many bytes.
     // In this case, it validates that description must have a least 0 byte,
     // which is a no-op.
-    min_bytes: 0,
+    min_bytes: 0
     // `max_bytes` specifies that a string field must have at most this many bytes.
     // In this case, it validates that description can have at most 500 bytes.
     max_bytes: 500

--- a/examples/option_string_match_pattern.proto
+++ b/examples/option_string_match_pattern.proto
@@ -27,9 +27,9 @@ message UserProfile {
     string: {
       // `pattern` specifies a regex pattern and validates that the string field
       // must match it.
-      pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}$",
-    },
-    ignore_empty: true,
+      pattern: "^(\\+\\d{1,2}\\s)?\\(?\\d{3}\\)?[\\s.-]\\d{3}[\\s.-]\\d{4}$"
+    }
+    ignore_empty: true
   }];
   // `hostname` specifies that the field value must be a valid hostname as defined
   // by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5).

--- a/examples/option_string_prefix_suffix.proto
+++ b/examples/option_string_prefix_suffix.proto
@@ -25,7 +25,7 @@ message GetDirectionRequest {
   string query = 1 [(buf.validate.field).string = {
     // `prefix` validates that a string field starts with this prefix.
     // This validates that the question starts with 'Where'.
-    prefix: "Where",
+    prefix: "Where"
     // `suffix` validates that a string field ends with this suffix.
     // This validates that the question ends with '?'.
     suffix: "?"

--- a/examples/option_timestamp_range.proto
+++ b/examples/option_timestamp_range.proto
@@ -27,7 +27,7 @@ message EventFromTheTwentiethCentury {
     // `gte` validates that a timestamp is greater than or equal to a value.
     // In this case, it validates the event happens at or after 1900-01-01T00:00:00Z,
     // which is 2208988800 seconds before the Unix epoch.
-    gte: {seconds: -2208988800},
+    gte: {seconds: -2208988800}
     // `le` validates that a timestamp is less than a value.
     // In this case, it validates the event happens before 2000-01-01T00:00:00Z,
     // which is 946684800 seconds after the Unix epoch.

--- a/examples/option_timestamp_relative_to_now.proto
+++ b/examples/option_timestamp_relative_to_now.proto
@@ -26,9 +26,9 @@ message BreakingNews {
     within: {seconds: 3600}
     // `lt_now` validates that a timestamp is before the current time when validation
     // takes place.
-    lt_now: true,
+    lt_now: true
     // Similarly, you can set `gt_now` to validate a timestamp in the future. Although
     // it is not necessary in this case.
-    gt_now: false,
+    gt_now: false
   }];
 }


### PR DESCRIPTION
Run `buf format -w examples`, which removes trailing commas in option fields.