### PR TITLE
Update CI to buf-action default behaviour

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,0 +1,17 @@
+name: Buf CI
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  delete:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
+        with:
+          token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -14,4 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-action@v1
         with:
-          token: ${{ secrets.BUF_TOKEN }}
+          push: false
+          archive: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           github_token: ${{ github.token }}
           format: true
           lint: true
-          breaking: true
+          breaking: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip breaking') }}
           push: false
           archive: false
       - name: Buf generate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,15 +29,6 @@ jobs:
         with:
           go-version: stable
           cache-dependency-path: go.work.sum
-      - name: Buf CI
-        uses: bufbuild/buf-action@v1
-        with:
-          github_token: ${{ github.token }}
-          format: true
-          lint: true
-          breaking: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'buf skip breaking') }}
-          push: false
-          archive: false
       - name: Buf generate
         run: |
           mkdir -p .tmp/bin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,10 @@ jobs:
         with:
           go-version: stable
           cache-dependency-path: go.work.sum
+      - name: Install buf
+        uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
       - name: Buf generate
         run: |
           mkdir -p .tmp/bin


### PR DESCRIPTION
Changes the CI behaviour to the defaults. Disables push & archive steps as the dep on v2 modules (which is fixed in #250).

Fixes https://github.com/bufbuild/protovalidate/pull/250