### PR TITLE
Fix doc examples for string.example

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -3732,8 +3732,8 @@ message StringRules {
   // ```proto
   // message MyString {
   //   string value = 1 [
-  //     (buf.validate.field).string.example = 1,
-  //     (buf.validate.field).string.example = 2
+  //     (buf.validate.field).string.example = "hello",
+  //     (buf.validate.field).string.example = "world"
   //   ];
   // }
   // ```

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -4663,8 +4663,8 @@ type StringRules struct {
 	//
 	//	message MyString {
 	//	  string value = 1 [
-	//	    (buf.validate.field).string.example = 1,
-	//	    (buf.validate.field).string.example = 2
+	//	    (buf.validate.field).string.example = "hello",
+	//	    (buf.validate.field).string.example = "world"
 	//	  ];
 	//	}
 	//


### PR DESCRIPTION
I noticed that the examples for string examples use integers, which is wrong. This PR updates them to actual strings.