### PR TITLE
Clarify that protovalidate does not require any code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ rules. The primary goal of `protovalidate` is to help developers ensure data
 consistency and integrity across the network without requiring generated code.
 
 > [!NOTE]
-> `protovalidate` is the spiritual successor to [protoc-gen-validate][pgv].
+> `protovalidate` is the spiritual successor to [protoc-gen-validate][pgv]. It does not require any code
+> generation and supports custom constraints.
 >
 > We recommend that new and existing projects transition to using `protovalidate` instead of `protoc-gen-validate`.
 >

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -5,6 +5,11 @@ incremental, and relatively painless, but it will still require a handful of
 operations to get there. To ease this burden, we've provided this documentation
 and a migration tool to simplify the process.
 
+> [!NOTE]
+> 
+> `protovalidate` does not require any code generation. The plugin `protoc-gen-valide`
+> is no longer needed, and shouldn't be used with `protovalidate`.
+
 ## Migration process
 
 1. **[OPTIONAL] Use `protovalidate` in legacy mode.** If supported, an

--- a/docs/migrate.md
+++ b/docs/migrate.md
@@ -7,7 +7,7 @@ and a migration tool to simplify the process.
 
 > [!NOTE]
 > 
-> `protovalidate` does not require any code generation. The plugin `protoc-gen-valide`
+> `protovalidate` does not require any code generation. The plugin `protoc-gen-validate`
 > is no longer needed, and shouldn't be used with `protovalidate`.
 
 ## Migration process


### PR DESCRIPTION
`protoc-gen-validate` is a plugin that generates validation code. `protovalidate` uses runtime libraries instead, and does not require code generation. 

This seems to be a frequent point of confusion for users when migrating. E.g. https://github.com/bufbuild/protovalidate/issues/275, https://github.com/bufbuild/protovalidate/issues/269, https://github.com/bufbuild/protovalidate/issues/177, https://github.com/bufbuild/protovalidate/issues/178, https://github.com/bufbuild/protovalidate/issues/73, https://github.com/bufbuild/protovalidate/issues/47.

I suggest we spell out this major difference in the main readme and the migration guide.