### PR TITLE
Add new test cases for URI encoding

### DIFF
--- a/tools/protovalidate-conformance/internal/cases/cases_strings.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_strings.go
@@ -1124,7 +1124,6 @@ func stringSuite() suites.Suite {
 				},
 			),
 		},
-
 		"uri_ref/invalid/not_checked/empty": {
 			Message:  &cases.StringNotURIRef{Val: ""},
 			Expected: results.Success(true),

--- a/tools/protovalidate-conformance/internal/cases/cases_strings.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_strings.go
@@ -1048,6 +1048,16 @@ func stringSuite() suites.Suite {
 				},
 			),
 		},
+		"uri/invalid/encoding": {
+			Message: &cases.StringURI{Val: "http://example.com/foo/bar?baz=%x"},
+			Expected: results.Violations(
+				&validate.Violation{
+					Field:        results.FieldPath("val"),
+					Rule:         results.FieldPath("string.uri"),
+					ConstraintId: proto.String("string.uri"),
+				},
+			),
+		},
 		"uri/invalid/not_checked/empty": {
 			Message:  &cases.StringNotURI{Val: ""},
 			Expected: results.Success(true),
@@ -1076,6 +1086,26 @@ func stringSuite() suites.Suite {
 				},
 			),
 		},
+		"uri/invalid/absolute/encoding": {
+			Message: &cases.StringURI{Val: "https://example.com/foo/bar?baz=%x"},
+			Expected: results.Violations(
+				&validate.Violation{
+					Field:        results.FieldPath("val"),
+					Rule:         results.FieldPath("string.uri"),
+					ConstraintId: proto.String("string.uri"),
+				},
+			),
+		},
+		"uri/invalid/relative/encoding": {
+			Message: &cases.StringURI{Val: "/foo/bar?baz=%x"},
+			Expected: results.Violations(
+				&validate.Violation{
+					Field:        results.FieldPath("val"),
+					Rule:         results.FieldPath("string.uri"),
+					ConstraintId: proto.String("string.uri"),
+				},
+			),
+		},
 		"uri_ref/valid/absolute": {
 			Message:  &cases.StringURIRef{Val: "https://example.com/foo/bar?baz=quux"},
 			Expected: results.Success(true),
@@ -1094,6 +1124,7 @@ func stringSuite() suites.Suite {
 				},
 			),
 		},
+
 		"uri_ref/invalid/not_checked/empty": {
 			Message:  &cases.StringNotURIRef{Val: ""},
 			Expected: results.Success(true),


### PR DESCRIPTION
This adds some additional conformance tests for validating the encoding of a query string in a URI.