### PR TITLE
Test against specific Go version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.23.x'
           cache-dependency-path: go.work.sum
       - name: Install buf
         uses: bufbuild/buf-action@v1


### PR DESCRIPTION
Two reasons for this:
* We should explicitly tests against the minimum Go version we advertise
* The version of Go needs to be updated in lockstep with the version of golangci-lint to avoid build errors.

The build started failing for new commits because Go 1.24 was release and started getting used in CI build, but we were pinned to an older golangci-lint.