### PR TITLE
Fix examples in validate.proto

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -587,7 +587,7 @@ message FloatRules {
   // ```proto
   // message MyFloat {
   //   // value must be in list [1.0, 2.0, 3.0]
-  //   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+  //   float value = 1 [(buf.validate.field).float = { in: [1.0, 2.0, 3.0] }];
   // }
   // ```
   repeated float in = 6 [(predefined).cel = {
@@ -602,7 +602,7 @@ message FloatRules {
   // ```proto
   // message MyFloat {
   //   // value must not be in list [1.0, 2.0, 3.0]
-  //   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+  //   float value = 1 [(buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] }];
   // }
   // ```
   repeated float not_in = 7 [(predefined).cel = {
@@ -808,7 +808,7 @@ message DoubleRules {
   // ```proto
   // message MyDouble {
   //   // value must be in list [1.0, 2.0, 3.0]
-  //   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+  //   double value = 1 [(buf.validate.field).double = { in: [1.0, 2.0, 3.0] }];
   // }
   // ```
   repeated double in = 6 [(predefined).cel = {
@@ -823,7 +823,7 @@ message DoubleRules {
   // ```proto
   // message MyDouble {
   //   // value must not be in list [1.0, 2.0, 3.0]
-  //   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+  //   double value = 1 [(buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] }];
   // }
   // ```
   repeated double not_in = 7 [(predefined).cel = {
@@ -1030,7 +1030,7 @@ message Int32Rules {
   // ```proto
   // message MyInt32 {
   //   // value must be in list [1, 2, 3]
-  //   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+  //   int32 value = 1 [(buf.validate.field).int32 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated int32 in = 6 [(predefined).cel = {
@@ -1045,7 +1045,7 @@ message Int32Rules {
   // ```proto
   // message MyInt32 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+  //   int32 value = 1 [(buf.validate.field).int32 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated int32 not_in = 7 [(predefined).cel = {
@@ -1245,7 +1245,7 @@ message Int64Rules {
   // ```proto
   // message MyInt64 {
   //   // value must be in list [1, 2, 3]
-  //   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+  //   int64 value = 1 [(buf.validate.field).int64 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated int64 in = 6 [(predefined).cel = {
@@ -1260,7 +1260,7 @@ message Int64Rules {
   // ```proto
   // message MyInt64 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+  //   int64 value = 1 [(buf.validate.field).int64 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated int64 not_in = 7 [(predefined).cel = {
@@ -1460,7 +1460,7 @@ message UInt32Rules {
   // ```proto
   // message MyUInt32 {
   //   // value must be in list [1, 2, 3]
-  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+  //   uint32 value = 1 [(buf.validate.field).uint32 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated uint32 in = 6 [(predefined).cel = {
@@ -1475,7 +1475,7 @@ message UInt32Rules {
   // ```proto
   // message MyUInt32 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+  //   uint32 value = 1 [(buf.validate.field).uint32 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated uint32 not_in = 7 [(predefined).cel = {
@@ -1674,7 +1674,7 @@ message UInt64Rules {
   // ```proto
   // message MyUInt64 {
   //   // value must be in list [1, 2, 3]
-  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+  //   uint64 value = 1 [(buf.validate.field).uint64 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated uint64 in = 6 [(predefined).cel = {
@@ -1689,7 +1689,7 @@ message UInt64Rules {
   // ```proto
   // message MyUInt64 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+  //   uint64 value = 1 [(buf.validate.field).uint64 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated uint64 not_in = 7 [(predefined).cel = {
@@ -1888,7 +1888,7 @@ message SInt32Rules {
   // ```proto
   // message MySInt32 {
   //   // value must be in list [1, 2, 3]
-  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+  //   sint32 value = 1 [(buf.validate.field).sint32 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated sint32 in = 6 [(predefined).cel = {
@@ -1903,7 +1903,7 @@ message SInt32Rules {
   // ```proto
   // message MySInt32 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+  //   sint32 value = 1 [(buf.validate.field).sint32 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated sint32 not_in = 7 [(predefined).cel = {
@@ -2102,7 +2102,7 @@ message SInt64Rules {
   // ```proto
   // message MySInt64 {
   //   // value must be in list [1, 2, 3]
-  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+  //   sint64 value = 1 [(buf.validate.field).sint64 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated sint64 in = 6 [(predefined).cel = {
@@ -2117,7 +2117,7 @@ message SInt64Rules {
   // ```proto
   // message MySInt64 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+  //   sint64 value = 1 [(buf.validate.field).sint64 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated sint64 not_in = 7 [(predefined).cel = {
@@ -2316,7 +2316,7 @@ message Fixed32Rules {
   // ```proto
   // message MyFixed32 {
   //   // value must be in list [1, 2, 3]
-  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+  //   fixed32 value = 1 [(buf.validate.field).fixed32 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated fixed32 in = 6 [(predefined).cel = {
@@ -2331,7 +2331,7 @@ message Fixed32Rules {
   // ```proto
   // message MyFixed32 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+  //   fixed32 value = 1 [(buf.validate.field).fixed32 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated fixed32 not_in = 7 [(predefined).cel = {
@@ -2530,7 +2530,7 @@ message Fixed64Rules {
   // ```proto
   // message MyFixed64 {
   //   // value must be in list [1, 2, 3]
-  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+  //   fixed64 value = 1 [(buf.validate.field).fixed64 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated fixed64 in = 6 [(predefined).cel = {
@@ -2545,7 +2545,7 @@ message Fixed64Rules {
   // ```proto
   // message MyFixed64 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+  //   fixed64 value = 1 [(buf.validate.field).fixed64 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated fixed64 not_in = 7 [(predefined).cel = {
@@ -2744,7 +2744,7 @@ message SFixed32Rules {
   // ```proto
   // message MySFixed32 {
   //   // value must be in list [1, 2, 3]
-  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+  //   sfixed32 value = 1 [(buf.validate.field).sfixed32 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated sfixed32 in = 6 [(predefined).cel = {
@@ -2759,7 +2759,7 @@ message SFixed32Rules {
   // ```proto
   // message MySFixed32 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+  //   sfixed32 value = 1 [(buf.validate.field).sfixed32 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated sfixed32 not_in = 7 [(predefined).cel = {
@@ -2958,7 +2958,7 @@ message SFixed64Rules {
   // ```proto
   // message MySFixed64 {
   //   // value must be in list [1, 2, 3]
-  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+  //   sfixed64 value = 1 [(buf.validate.field).sfixed64 = { in: [1, 2, 3] }];
   // }
   // ```
   repeated sfixed64 in = 6 [(predefined).cel = {
@@ -2973,7 +2973,7 @@ message SFixed64Rules {
   // ```proto
   // message MySFixed64 {
   //   // value must not be in list [1, 2, 3]
-  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+  //   sfixed64 value = 1 [(buf.validate.field).sfixed64 = { not_in: [1, 2, 3] }];
   // }
   // ```
   repeated sfixed64 not_in = 7 [(predefined).cel = {
@@ -3253,7 +3253,7 @@ message StringRules {
   // ```proto
   // message MyString {
   //   // value must be in list ["apple", "banana"]
-  //   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+  //   string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
   // }
   // ```
   repeated string in = 10 [(predefined).cel = {
@@ -3267,7 +3267,7 @@ message StringRules {
   // ```proto
   // message MyString {
   //   // value must not be in list ["orange", "grape"]
-  //   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+  //   string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
   // }
   // ```
   repeated string not_in = 11 [(predefined).cel = {

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -1099,7 +1099,7 @@ type FloatRules struct {
 	//
 	//	message MyFloat {
 	//	  // value must be in list [1.0, 2.0, 3.0]
-	//	  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+	//	  float value = 1 [(buf.validate.field).float = { in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
 	// ```
@@ -1112,7 +1112,7 @@ type FloatRules struct {
 	//
 	//	message MyFloat {
 	//	  // value must not be in list [1.0, 2.0, 3.0]
-	//	  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+	//	  float value = 1 [(buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
 	// ```
@@ -1385,7 +1385,7 @@ type DoubleRules struct {
 	//
 	//	message MyDouble {
 	//	  // value must be in list [1.0, 2.0, 3.0]
-	//	  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+	//	  double value = 1 [(buf.validate.field).double = { in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
 	// ```
@@ -1398,7 +1398,7 @@ type DoubleRules struct {
 	//
 	//	message MyDouble {
 	//	  // value must not be in list [1.0, 2.0, 3.0]
-	//	  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+	//	  double value = 1 [(buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] }];
 	//	}
 	//
 	// ```
@@ -1671,7 +1671,7 @@ type Int32Rules struct {
 	//
 	//	message MyInt32 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+	//	  int32 value = 1 [(buf.validate.field).int32 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -1684,7 +1684,7 @@ type Int32Rules struct {
 	//
 	//	message MyInt32 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+	//	  int32 value = 1 [(buf.validate.field).int32 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -1947,7 +1947,7 @@ type Int64Rules struct {
 	//
 	//	message MyInt64 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+	//	  int64 value = 1 [(buf.validate.field).int64 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -1960,7 +1960,7 @@ type Int64Rules struct {
 	//
 	//	message MyInt64 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+	//	  int64 value = 1 [(buf.validate.field).int64 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2223,7 +2223,7 @@ type UInt32Rules struct {
 	//
 	//	message MyUInt32 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+	//	  uint32 value = 1 [(buf.validate.field).uint32 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2236,7 +2236,7 @@ type UInt32Rules struct {
 	//
 	//	message MyUInt32 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+	//	  uint32 value = 1 [(buf.validate.field).uint32 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2499,7 +2499,7 @@ type UInt64Rules struct {
 	//
 	//	message MyUInt64 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+	//	  uint64 value = 1 [(buf.validate.field).uint64 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2512,7 +2512,7 @@ type UInt64Rules struct {
 	//
 	//	message MyUInt64 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+	//	  uint64 value = 1 [(buf.validate.field).uint64 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2774,7 +2774,7 @@ type SInt32Rules struct {
 	//
 	//	message MySInt32 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+	//	  sint32 value = 1 [(buf.validate.field).sint32 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -2787,7 +2787,7 @@ type SInt32Rules struct {
 	//
 	//	message MySInt32 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+	//	  sint32 value = 1 [(buf.validate.field).sint32 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3049,7 +3049,7 @@ type SInt64Rules struct {
 	//
 	//	message MySInt64 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+	//	  sint64 value = 1 [(buf.validate.field).sint64 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3062,7 +3062,7 @@ type SInt64Rules struct {
 	//
 	//	message MySInt64 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+	//	  sint64 value = 1 [(buf.validate.field).sint64 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3324,7 +3324,7 @@ type Fixed32Rules struct {
 	//
 	//	message MyFixed32 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+	//	  fixed32 value = 1 [(buf.validate.field).fixed32 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3337,7 +3337,7 @@ type Fixed32Rules struct {
 	//
 	//	message MyFixed32 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+	//	  fixed32 value = 1 [(buf.validate.field).fixed32 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3599,7 +3599,7 @@ type Fixed64Rules struct {
 	//
 	//	message MyFixed64 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+	//	  fixed64 value = 1 [(buf.validate.field).fixed64 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3612,7 +3612,7 @@ type Fixed64Rules struct {
 	//
 	//	message MyFixed64 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+	//	  fixed64 value = 1 [(buf.validate.field).fixed64 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3874,7 +3874,7 @@ type SFixed32Rules struct {
 	//
 	//	message MySFixed32 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -3887,7 +3887,7 @@ type SFixed32Rules struct {
 	//
 	//	message MySFixed32 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+	//	  sfixed32 value = 1 [(buf.validate.field).sfixed32 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -4149,7 +4149,7 @@ type SFixed64Rules struct {
 	//
 	//	message MySFixed64 {
 	//	  // value must be in list [1, 2, 3]
-	//	  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64 = { in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -4162,7 +4162,7 @@ type SFixed64Rules struct {
 	//
 	//	message MySFixed64 {
 	//	  // value must not be in list [1, 2, 3]
-	//	  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+	//	  sfixed64 value = 1 [(buf.validate.field).sfixed64 = { not_in: [1, 2, 3] }];
 	//	}
 	//
 	// ```
@@ -4643,7 +4643,7 @@ type StringRules struct {
 	//
 	//	message MyString {
 	//	  // value must be in list ["apple", "banana"]
-	//	  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+	//	  string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
 	//	}
 	//
 	// ```
@@ -4655,7 +4655,7 @@ type StringRules struct {
 	//
 	//	message MyString {
 	//	  // value must not be in list ["orange", "grape"]
-	//	  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+	//	  string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
 	//	}
 	//
 	// ```


### PR DESCRIPTION
I noticed an example given in validate.proto that doesn't compile. This fixes the example, and similar errors.