### PR TITLE
Print unexpected success cases in the conformance runner

### DIFF
--- a/tools/protovalidate-conformance/internal/results/set.go
+++ b/tools/protovalidate-conformance/internal/results/set.go
@@ -70,7 +70,9 @@ func (suite *SuiteResults) AddCase(res *harness.CaseResult, verbose bool) {
 	default:
 		suite.Failures++
 	}
-	if verbose || (!res.GetSuccess() && !res.GetExpectedFailure()) {
+	unexpectedFailure := !res.GetSuccess() && !res.GetExpectedFailure()
+	unexpectedSuccess := res.GetSuccess() && res.GetExpectedFailure()
+	if verbose || unexpectedFailure || unexpectedSuccess {
 		suite.Cases = append(suite.Cases, res)
 	}
 }


### PR DESCRIPTION
As a follow-up to https://github.com/bufbuild/protovalidate/pull/331, do print unexpected success cases in the conformance runner.

For example, this test case is expected to fail:

```yaml
# expected_failures.yaml
custom_constraints:
  - no_expressions/empty
```

Once the issue is fixed and the case passes, the runner reports a failure. But it doesn't show which case caused the failure:

```
--- FAIL: custom_constraints (failed: 1, skipped: 0, passed: 1, total: 2)
```

This PR changes the behavior to print such unexpected success cases:

```
--- FAIL: custom_constraints (failed: 1, skipped: 0, passed: 1, total: 2)
    --- PASS: no_expressions/empty
```
