### PR TITLE
Fix erroneous IGNORE_ALWAYS in conformance test case

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto2.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto2.proto
@@ -19,16 +19,12 @@ package buf.validate.conformance.cases;
 import "buf/validate/validate.proto";
 
 message RequiredProto2ScalarOptional {
-  optional string val = 1 [
-    (buf.validate.field).required = true,
-    (buf.validate.field).ignore = IGNORE_ALWAYS
-  ];
+  optional string val = 1 [(buf.validate.field).required = true];
 }
 
 message RequiredProto2ScalarOptionalDefault {
   optional string val = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).ignore = IGNORE_ALWAYS,
     default = "foo"
   ];
 }

--- a/tools/internal/gen/buf/validate/conformance/cases/required_field_proto2.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/required_field_proto2.pb.go
@@ -435,11 +435,11 @@ var File_buf_validate_conformance_cases_required_field_proto2_proto protoreflect
 
 const file_buf_validate_conformance_cases_required_field_proto2_proto_rawDesc = "" +
 	"\n" +
-	":buf/validate/conformance/cases/required_field_proto2.proto\x12\x1ebuf.validate.conformance.cases\x1a\x1bbuf/validate/validate.proto\";\n" +
-	"\x1cRequiredProto2ScalarOptional\x12\x1b\n" +
-	"\x03val\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"G\n" +
-	"#RequiredProto2ScalarOptionalDefault\x12 \n" +
-	"\x03val\x18\x01 \x01(\t:\x03fooB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"8\n" +
+	":buf/validate/conformance/cases/required_field_proto2.proto\x12\x1ebuf.validate.conformance.cases\x1a\x1bbuf/validate/validate.proto\"8\n" +
+	"\x1cRequiredProto2ScalarOptional\x12\x18\n" +
+	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"D\n" +
+	"#RequiredProto2ScalarOptionalDefault\x12\x1d\n" +
+	"\x03val\x18\x01 \x01(\t:\x03fooB\x06\xbaH\x03\xc8\x01\x01R\x03val\"8\n" +
 	"\x1cRequiredProto2ScalarRequired\x12\x18\n" +
 	"\x03val\x18\x01 \x02(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"\x85\x01\n" +
 	"\x15RequiredProto2Message\x12S\n" +


### PR DESCRIPTION
https://github.com/bufbuild/protovalidate/pull/322 added test coverage for IGNORE_ALWAYS. By mistake, IGNORE_ALWAYS was also set for two unrelated fields in the file required_field_proto2.proto.

This went unnoticed while running against protovalidate-go and protovalidate-java, but @smaye81 noticed two inexplicably failing tests while working on protovalidate-python (thanks!).
