### PR TITLE
Add tests for required with IGNORE_ALWAYS

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto2.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto2.proto
@@ -21,11 +21,24 @@ import "buf/validate/validate.proto";
 message RequiredProto2ScalarOptional {
   optional string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredProto2ScalarOptionalIgnoreAlways {
+  optional string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredProto2ScalarOptionalDefault {
   optional string val = 1 [
     (buf.validate.field).required = true,
     default = "foo"
+  ];
+}
+message RequiredProto2ScalarOptionalDefaultIgnoreAlways {
+  optional string val = 1 [
+    (buf.validate.field).required = true,
+    default = "foo",
+    (buf.validate.field).ignore = IGNORE_ALWAYS
   ];
 }
 
@@ -39,6 +52,15 @@ message RequiredProto2Message {
     optional string val = 1;
   }
 }
+message RequiredProto2MessageIgnoreAlways {
+  optional Msg val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+  message Msg {
+    optional string val = 1;
+  }
+}
 
 message RequiredProto2Oneof {
   oneof val {
@@ -46,11 +68,32 @@ message RequiredProto2Oneof {
     string b = 2;
   }
 }
+message RequiredProto2OneofIgnoreAlways {
+  oneof val {
+    string a = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).ignore = IGNORE_ALWAYS
+    ];
+    string b = 2;
+  }
+}
 
 message RequiredProto2Repeated {
   repeated string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredProto2RepeatedIgnoreAlways {
+  repeated string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredProto2Map {
   map<string, string> val = 1 [(buf.validate.field).required = true];
+}
+message RequiredProto2MapIgnoreAlways {
+  map<string, string> val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto3.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto3.proto
@@ -21,13 +21,34 @@ import "buf/validate/validate.proto";
 message RequiredProto3Scalar {
   string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredProto3ScalarIgnoreAlways {
+  string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredProto3OptionalScalar {
   optional string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredProto3OptionalScalarIgnoreAlways {
+  optional string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredProto3Message {
   Msg val = 1 [(buf.validate.field).required = true];
+  message Msg {
+    string val = 1;
+  }
+}
+message RequiredProto3MessageIgnoreAlways {
+  Msg val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
   message Msg {
     string val = 1;
   }
@@ -39,11 +60,32 @@ message RequiredProto3OneOf {
     string b = 2;
   }
 }
+message RequiredProto3OneOfIgnoreAlways {
+  oneof val {
+    string a = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).ignore = IGNORE_ALWAYS
+    ];
+    string b = 2;
+  }
+}
 
 message RequiredProto3Repeated {
   repeated string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredProto3RepeatedIgnoreAlways {
+  repeated string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredProto3Map {
   map<string, string> val = 1 [(buf.validate.field).required = true];
+}
+message RequiredProto3MapIgnoreAlways {
+  map<string, string> val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto_editions.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto_editions.proto
@@ -21,6 +21,12 @@ import "buf/validate/validate.proto";
 message RequiredEditionsScalarExplicitPresence {
   string val = 1 [(buf.validate.field).required = true];
 }
+message RequiredEditionsScalarExplicitPresenceIgnoreAlways {
+  string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredEditionsScalarExplicitPresenceDefault {
   string val = 1 [
@@ -28,11 +34,25 @@ message RequiredEditionsScalarExplicitPresenceDefault {
     default = "foo"
   ];
 }
+message RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways {
+  string val = 1 [
+    (buf.validate.field).required = true,
+    default = "foo",
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredEditionsScalarImplicitPresence {
   string val = 1 [
     features.field_presence = IMPLICIT,
     (buf.validate.field).required = true
+  ];
+}
+message RequiredEditionsScalarImplicitPresenceIgnoreAlways {
+  string val = 1 [
+    features.field_presence = IMPLICIT,
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
   ];
 }
 
@@ -49,11 +69,30 @@ message RequiredEditionsMessageExplicitPresence {
     string val = 1;
   }
 }
+message RequiredEditionsMessageExplicitPresenceIgnoreAlways {
+  Msg val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+  message Msg {
+    string val = 1;
+  }
+}
 
 message RequiredEditionsMessageExplicitPresenceDelimited {
   Msg val = 1 [
     features.message_encoding = DELIMITED,
     (buf.validate.field).required = true
+  ];
+  message Msg {
+    string val = 1;
+  }
+}
+message RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways {
+  Msg val = 1 [
+    features.message_encoding = DELIMITED,
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
   ];
   message Msg {
     string val = 1;
@@ -87,9 +126,24 @@ message RequiredEditionsOneof {
     string b = 2;
   }
 }
+message RequiredEditionsOneofIgnoreAlways {
+  oneof val {
+    string a = 1 [
+      (buf.validate.field).required = true,
+      (buf.validate.field).ignore = IGNORE_ALWAYS
+    ];
+    string b = 2;
+  }
+}
 
 message RequiredEditionsRepeated {
   repeated string val = 1 [(buf.validate.field).required = true];
+}
+message RequiredEditionsRepeatedIgnoreAlways {
+  repeated string val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
 }
 
 message RequiredEditionsRepeatedExpanded {
@@ -98,7 +152,20 @@ message RequiredEditionsRepeatedExpanded {
     (buf.validate.field).required = true
   ];
 }
+message RequiredEditionsRepeatedExpandedIgnoreAlways {
+  repeated string val = 1 [
+    features.repeated_field_encoding = EXPANDED,
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
+}
 
 message RequiredEditionsMap {
   map<string, string> val = 1 [(buf.validate.field).required = true];
+}
+message RequiredEditionsMapIgnoreAlways {
+  map<string, string> val = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).ignore = IGNORE_ALWAYS
+  ];
 }

--- a/tools/internal/gen/buf/validate/conformance/cases/required_field_proto2.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/required_field_proto2.pb.go
@@ -80,6 +80,50 @@ func (x *RequiredProto2ScalarOptional) GetVal() string {
 	return ""
 }
 
+type RequiredProto2ScalarOptionalIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2ScalarOptionalIgnoreAlways) Reset() {
+	*x = RequiredProto2ScalarOptionalIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2ScalarOptionalIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2ScalarOptionalIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2ScalarOptionalIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2ScalarOptionalIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2ScalarOptionalIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RequiredProto2ScalarOptionalIgnoreAlways) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
 type RequiredProto2ScalarOptionalDefault struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           *string                `protobuf:"bytes,1,opt,name=val,def=foo" json:"val,omitempty"`
@@ -94,7 +138,7 @@ const (
 
 func (x *RequiredProto2ScalarOptionalDefault) Reset() {
 	*x = RequiredProto2ScalarOptionalDefault{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -106,7 +150,7 @@ func (x *RequiredProto2ScalarOptionalDefault) String() string {
 func (*RequiredProto2ScalarOptionalDefault) ProtoMessage() {}
 
 func (x *RequiredProto2ScalarOptionalDefault) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -119,7 +163,7 @@ func (x *RequiredProto2ScalarOptionalDefault) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use RequiredProto2ScalarOptionalDefault.ProtoReflect.Descriptor instead.
 func (*RequiredProto2ScalarOptionalDefault) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{1}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RequiredProto2ScalarOptionalDefault) GetVal() string {
@@ -127,6 +171,55 @@ func (x *RequiredProto2ScalarOptionalDefault) GetVal() string {
 		return *x.Val
 	}
 	return Default_RequiredProto2ScalarOptionalDefault_Val
+}
+
+type RequiredProto2ScalarOptionalDefaultIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val,def=foo" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+// Default values for RequiredProto2ScalarOptionalDefaultIgnoreAlways fields.
+const (
+	Default_RequiredProto2ScalarOptionalDefaultIgnoreAlways_Val = string("foo")
+)
+
+func (x *RequiredProto2ScalarOptionalDefaultIgnoreAlways) Reset() {
+	*x = RequiredProto2ScalarOptionalDefaultIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2ScalarOptionalDefaultIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2ScalarOptionalDefaultIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2ScalarOptionalDefaultIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2ScalarOptionalDefaultIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2ScalarOptionalDefaultIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RequiredProto2ScalarOptionalDefaultIgnoreAlways) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return Default_RequiredProto2ScalarOptionalDefaultIgnoreAlways_Val
 }
 
 type RequiredProto2ScalarRequired struct {
@@ -138,7 +231,7 @@ type RequiredProto2ScalarRequired struct {
 
 func (x *RequiredProto2ScalarRequired) Reset() {
 	*x = RequiredProto2ScalarRequired{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -150,7 +243,7 @@ func (x *RequiredProto2ScalarRequired) String() string {
 func (*RequiredProto2ScalarRequired) ProtoMessage() {}
 
 func (x *RequiredProto2ScalarRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -163,7 +256,7 @@ func (x *RequiredProto2ScalarRequired) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2ScalarRequired.ProtoReflect.Descriptor instead.
 func (*RequiredProto2ScalarRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{2}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RequiredProto2ScalarRequired) GetVal() string {
@@ -182,7 +275,7 @@ type RequiredProto2Message struct {
 
 func (x *RequiredProto2Message) Reset() {
 	*x = RequiredProto2Message{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -194,7 +287,7 @@ func (x *RequiredProto2Message) String() string {
 func (*RequiredProto2Message) ProtoMessage() {}
 
 func (x *RequiredProto2Message) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -207,10 +300,54 @@ func (x *RequiredProto2Message) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2Message.ProtoReflect.Descriptor instead.
 func (*RequiredProto2Message) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{3}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RequiredProto2Message) GetVal() *RequiredProto2Message_Msg {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto2MessageIgnoreAlways struct {
+	state         protoimpl.MessageState                 `protogen:"open.v1"`
+	Val           *RequiredProto2MessageIgnoreAlways_Msg `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2MessageIgnoreAlways) Reset() {
+	*x = RequiredProto2MessageIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2MessageIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2MessageIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2MessageIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2MessageIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2MessageIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *RequiredProto2MessageIgnoreAlways) GetVal() *RequiredProto2MessageIgnoreAlways_Msg {
 	if x != nil {
 		return x.Val
 	}
@@ -230,7 +367,7 @@ type RequiredProto2Oneof struct {
 
 func (x *RequiredProto2Oneof) Reset() {
 	*x = RequiredProto2Oneof{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -242,7 +379,7 @@ func (x *RequiredProto2Oneof) String() string {
 func (*RequiredProto2Oneof) ProtoMessage() {}
 
 func (x *RequiredProto2Oneof) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -255,7 +392,7 @@ func (x *RequiredProto2Oneof) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2Oneof.ProtoReflect.Descriptor instead.
 func (*RequiredProto2Oneof) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{4}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RequiredProto2Oneof) GetVal() isRequiredProto2Oneof_Val {
@@ -299,6 +436,88 @@ func (*RequiredProto2Oneof_A) isRequiredProto2Oneof_Val() {}
 
 func (*RequiredProto2Oneof_B) isRequiredProto2Oneof_Val() {}
 
+type RequiredProto2OneofIgnoreAlways struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Val:
+	//
+	//	*RequiredProto2OneofIgnoreAlways_A
+	//	*RequiredProto2OneofIgnoreAlways_B
+	Val           isRequiredProto2OneofIgnoreAlways_Val `protobuf_oneof:"val"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2OneofIgnoreAlways) Reset() {
+	*x = RequiredProto2OneofIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2OneofIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2OneofIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2OneofIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2OneofIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2OneofIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *RequiredProto2OneofIgnoreAlways) GetVal() isRequiredProto2OneofIgnoreAlways_Val {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+func (x *RequiredProto2OneofIgnoreAlways) GetA() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredProto2OneofIgnoreAlways_A); ok {
+			return x.A
+		}
+	}
+	return ""
+}
+
+func (x *RequiredProto2OneofIgnoreAlways) GetB() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredProto2OneofIgnoreAlways_B); ok {
+			return x.B
+		}
+	}
+	return ""
+}
+
+type isRequiredProto2OneofIgnoreAlways_Val interface {
+	isRequiredProto2OneofIgnoreAlways_Val()
+}
+
+type RequiredProto2OneofIgnoreAlways_A struct {
+	A string `protobuf:"bytes,1,opt,name=a,oneof"`
+}
+
+type RequiredProto2OneofIgnoreAlways_B struct {
+	B string `protobuf:"bytes,2,opt,name=b,oneof"`
+}
+
+func (*RequiredProto2OneofIgnoreAlways_A) isRequiredProto2OneofIgnoreAlways_Val() {}
+
+func (*RequiredProto2OneofIgnoreAlways_B) isRequiredProto2OneofIgnoreAlways_Val() {}
+
 type RequiredProto2Repeated struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           []string               `protobuf:"bytes,1,rep,name=val" json:"val,omitempty"`
@@ -308,7 +527,7 @@ type RequiredProto2Repeated struct {
 
 func (x *RequiredProto2Repeated) Reset() {
 	*x = RequiredProto2Repeated{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -320,7 +539,7 @@ func (x *RequiredProto2Repeated) String() string {
 func (*RequiredProto2Repeated) ProtoMessage() {}
 
 func (x *RequiredProto2Repeated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -333,10 +552,54 @@ func (x *RequiredProto2Repeated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2Repeated.ProtoReflect.Descriptor instead.
 func (*RequiredProto2Repeated) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{5}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RequiredProto2Repeated) GetVal() []string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto2RepeatedIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           []string               `protobuf:"bytes,1,rep,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2RepeatedIgnoreAlways) Reset() {
+	*x = RequiredProto2RepeatedIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2RepeatedIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2RepeatedIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2RepeatedIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2RepeatedIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2RepeatedIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *RequiredProto2RepeatedIgnoreAlways) GetVal() []string {
 	if x != nil {
 		return x.Val
 	}
@@ -352,7 +615,7 @@ type RequiredProto2Map struct {
 
 func (x *RequiredProto2Map) Reset() {
 	*x = RequiredProto2Map{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -364,7 +627,7 @@ func (x *RequiredProto2Map) String() string {
 func (*RequiredProto2Map) ProtoMessage() {}
 
 func (x *RequiredProto2Map) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -377,10 +640,54 @@ func (x *RequiredProto2Map) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2Map.ProtoReflect.Descriptor instead.
 func (*RequiredProto2Map) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{6}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RequiredProto2Map) GetVal() map[string]string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto2MapIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           map[string]string      `protobuf:"bytes,1,rep,name=val" json:"val,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2MapIgnoreAlways) Reset() {
+	*x = RequiredProto2MapIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2MapIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2MapIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto2MapIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2MapIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto2MapIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *RequiredProto2MapIgnoreAlways) GetVal() map[string]string {
 	if x != nil {
 		return x.Val
 	}
@@ -396,7 +703,7 @@ type RequiredProto2Message_Msg struct {
 
 func (x *RequiredProto2Message_Msg) Reset() {
 	*x = RequiredProto2Message_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -408,7 +715,7 @@ func (x *RequiredProto2Message_Msg) String() string {
 func (*RequiredProto2Message_Msg) ProtoMessage() {}
 
 func (x *RequiredProto2Message_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -421,10 +728,54 @@ func (x *RequiredProto2Message_Msg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto2Message_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredProto2Message_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{3, 0}
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{5, 0}
 }
 
 func (x *RequiredProto2Message_Msg) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
+type RequiredProto2MessageIgnoreAlways_Msg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto2MessageIgnoreAlways_Msg) Reset() {
+	*x = RequiredProto2MessageIgnoreAlways_Msg{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto2MessageIgnoreAlways_Msg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto2MessageIgnoreAlways_Msg) ProtoMessage() {}
+
+func (x *RequiredProto2MessageIgnoreAlways_Msg) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto2MessageIgnoreAlways_Msg.ProtoReflect.Descriptor instead.
+func (*RequiredProto2MessageIgnoreAlways_Msg) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP(), []int{6, 0}
+}
+
+func (x *RequiredProto2MessageIgnoreAlways_Msg) GetVal() string {
 	if x != nil && x.Val != nil {
 		return *x.Val
 	}
@@ -437,23 +788,42 @@ const file_buf_validate_conformance_cases_required_field_proto2_proto_rawDesc = 
 	"\n" +
 	":buf/validate/conformance/cases/required_field_proto2.proto\x12\x1ebuf.validate.conformance.cases\x1a\x1bbuf/validate/validate.proto\"8\n" +
 	"\x1cRequiredProto2ScalarOptional\x12\x18\n" +
-	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"D\n" +
+	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"G\n" +
+	"(RequiredProto2ScalarOptionalIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"D\n" +
 	"#RequiredProto2ScalarOptionalDefault\x12\x1d\n" +
-	"\x03val\x18\x01 \x01(\t:\x03fooB\x06\xbaH\x03\xc8\x01\x01R\x03val\"8\n" +
+	"\x03val\x18\x01 \x01(\t:\x03fooB\x06\xbaH\x03\xc8\x01\x01R\x03val\"S\n" +
+	"/RequiredProto2ScalarOptionalDefaultIgnoreAlways\x12 \n" +
+	"\x03val\x18\x01 \x01(\t:\x03fooB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"8\n" +
 	"\x1cRequiredProto2ScalarRequired\x12\x18\n" +
 	"\x03val\x18\x01 \x02(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"\x85\x01\n" +
 	"\x15RequiredProto2Message\x12S\n" +
 	"\x03val\x18\x01 \x01(\v29.buf.validate.conformance.cases.RequiredProto2Message.MsgB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a\x17\n" +
 	"\x03Msg\x12\x10\n" +
+	"\x03val\x18\x01 \x01(\tR\x03val\"\xa0\x01\n" +
+	"!RequiredProto2MessageIgnoreAlways\x12b\n" +
+	"\x03val\x18\x01 \x01(\v2E.buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.MsgB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a\x17\n" +
+	"\x03Msg\x12\x10\n" +
 	"\x03val\x18\x01 \x01(\tR\x03val\"D\n" +
 	"\x13RequiredProto2Oneof\x12\x16\n" +
 	"\x01a\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01H\x00R\x01a\x12\x0e\n" +
 	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
+	"\x03val\"S\n" +
+	"\x1fRequiredProto2OneofIgnoreAlways\x12\x19\n" +
+	"\x01a\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03H\x00R\x01a\x12\x0e\n" +
+	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
 	"\x03val\"2\n" +
 	"\x16RequiredProto2Repeated\x12\x18\n" +
-	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"\xa1\x01\n" +
+	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"A\n" +
+	"\"RequiredProto2RepeatedIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x03(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"\xa1\x01\n" +
 	"\x11RequiredProto2Map\x12T\n" +
 	"\x03val\x18\x01 \x03(\v2:.buf.validate.conformance.cases.RequiredProto2Map.ValEntryB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a6\n" +
+	"\bValEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbc\x01\n" +
+	"\x1dRequiredProto2MapIgnoreAlways\x12c\n" +
+	"\x03val\x18\x01 \x03(\v2F.buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways.ValEntryB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a6\n" +
 	"\bValEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\xaf\x02\n" +
@@ -471,26 +841,36 @@ func file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescGZIP
 	return file_buf_validate_conformance_cases_required_field_proto2_proto_rawDescData
 }
 
-var file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_buf_validate_conformance_cases_required_field_proto2_proto_goTypes = []any{
-	(*RequiredProto2ScalarOptional)(nil),        // 0: buf.validate.conformance.cases.RequiredProto2ScalarOptional
-	(*RequiredProto2ScalarOptionalDefault)(nil), // 1: buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefault
-	(*RequiredProto2ScalarRequired)(nil),        // 2: buf.validate.conformance.cases.RequiredProto2ScalarRequired
-	(*RequiredProto2Message)(nil),               // 3: buf.validate.conformance.cases.RequiredProto2Message
-	(*RequiredProto2Oneof)(nil),                 // 4: buf.validate.conformance.cases.RequiredProto2Oneof
-	(*RequiredProto2Repeated)(nil),              // 5: buf.validate.conformance.cases.RequiredProto2Repeated
-	(*RequiredProto2Map)(nil),                   // 6: buf.validate.conformance.cases.RequiredProto2Map
-	(*RequiredProto2Message_Msg)(nil),           // 7: buf.validate.conformance.cases.RequiredProto2Message.Msg
-	nil,                                         // 8: buf.validate.conformance.cases.RequiredProto2Map.ValEntry
+	(*RequiredProto2ScalarOptional)(nil),                    // 0: buf.validate.conformance.cases.RequiredProto2ScalarOptional
+	(*RequiredProto2ScalarOptionalIgnoreAlways)(nil),        // 1: buf.validate.conformance.cases.RequiredProto2ScalarOptionalIgnoreAlways
+	(*RequiredProto2ScalarOptionalDefault)(nil),             // 2: buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefault
+	(*RequiredProto2ScalarOptionalDefaultIgnoreAlways)(nil), // 3: buf.validate.conformance.cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways
+	(*RequiredProto2ScalarRequired)(nil),                    // 4: buf.validate.conformance.cases.RequiredProto2ScalarRequired
+	(*RequiredProto2Message)(nil),                           // 5: buf.validate.conformance.cases.RequiredProto2Message
+	(*RequiredProto2MessageIgnoreAlways)(nil),               // 6: buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways
+	(*RequiredProto2Oneof)(nil),                             // 7: buf.validate.conformance.cases.RequiredProto2Oneof
+	(*RequiredProto2OneofIgnoreAlways)(nil),                 // 8: buf.validate.conformance.cases.RequiredProto2OneofIgnoreAlways
+	(*RequiredProto2Repeated)(nil),                          // 9: buf.validate.conformance.cases.RequiredProto2Repeated
+	(*RequiredProto2RepeatedIgnoreAlways)(nil),              // 10: buf.validate.conformance.cases.RequiredProto2RepeatedIgnoreAlways
+	(*RequiredProto2Map)(nil),                               // 11: buf.validate.conformance.cases.RequiredProto2Map
+	(*RequiredProto2MapIgnoreAlways)(nil),                   // 12: buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways
+	(*RequiredProto2Message_Msg)(nil),                       // 13: buf.validate.conformance.cases.RequiredProto2Message.Msg
+	(*RequiredProto2MessageIgnoreAlways_Msg)(nil),           // 14: buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg
+	nil, // 15: buf.validate.conformance.cases.RequiredProto2Map.ValEntry
+	nil, // 16: buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways.ValEntry
 }
 var file_buf_validate_conformance_cases_required_field_proto2_proto_depIdxs = []int32{
-	7, // 0: buf.validate.conformance.cases.RequiredProto2Message.val:type_name -> buf.validate.conformance.cases.RequiredProto2Message.Msg
-	8, // 1: buf.validate.conformance.cases.RequiredProto2Map.val:type_name -> buf.validate.conformance.cases.RequiredProto2Map.ValEntry
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	13, // 0: buf.validate.conformance.cases.RequiredProto2Message.val:type_name -> buf.validate.conformance.cases.RequiredProto2Message.Msg
+	14, // 1: buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto2MessageIgnoreAlways.Msg
+	15, // 2: buf.validate.conformance.cases.RequiredProto2Map.val:type_name -> buf.validate.conformance.cases.RequiredProto2Map.ValEntry
+	16, // 3: buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto2MapIgnoreAlways.ValEntry
+	4,  // [4:4] is the sub-list for method output_type
+	4,  // [4:4] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_buf_validate_conformance_cases_required_field_proto2_proto_init() }
@@ -498,9 +878,13 @@ func file_buf_validate_conformance_cases_required_field_proto2_proto_init() {
 	if File_buf_validate_conformance_cases_required_field_proto2_proto != nil {
 		return
 	}
-	file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[4].OneofWrappers = []any{
+	file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[7].OneofWrappers = []any{
 		(*RequiredProto2Oneof_A)(nil),
 		(*RequiredProto2Oneof_B)(nil),
+	}
+	file_buf_validate_conformance_cases_required_field_proto2_proto_msgTypes[8].OneofWrappers = []any{
+		(*RequiredProto2OneofIgnoreAlways_A)(nil),
+		(*RequiredProto2OneofIgnoreAlways_B)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -508,7 +892,7 @@ func file_buf_validate_conformance_cases_required_field_proto2_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_required_field_proto2_proto_rawDesc), len(file_buf_validate_conformance_cases_required_field_proto2_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/tools/internal/gen/buf/validate/conformance/cases/required_field_proto3.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/required_field_proto3.pb.go
@@ -80,6 +80,50 @@ func (x *RequiredProto3Scalar) GetVal() string {
 	return ""
 }
 
+type RequiredProto3ScalarIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3ScalarIgnoreAlways) Reset() {
+	*x = RequiredProto3ScalarIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3ScalarIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3ScalarIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3ScalarIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3ScalarIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3ScalarIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RequiredProto3ScalarIgnoreAlways) GetVal() string {
+	if x != nil {
+		return x.Val
+	}
+	return ""
+}
+
 type RequiredProto3OptionalScalar struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           *string                `protobuf:"bytes,1,opt,name=val,proto3,oneof" json:"val,omitempty"`
@@ -89,7 +133,7 @@ type RequiredProto3OptionalScalar struct {
 
 func (x *RequiredProto3OptionalScalar) Reset() {
 	*x = RequiredProto3OptionalScalar{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -101,7 +145,7 @@ func (x *RequiredProto3OptionalScalar) String() string {
 func (*RequiredProto3OptionalScalar) ProtoMessage() {}
 
 func (x *RequiredProto3OptionalScalar) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -114,10 +158,54 @@ func (x *RequiredProto3OptionalScalar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3OptionalScalar.ProtoReflect.Descriptor instead.
 func (*RequiredProto3OptionalScalar) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{1}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RequiredProto3OptionalScalar) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
+type RequiredProto3OptionalScalarIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val,proto3,oneof" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3OptionalScalarIgnoreAlways) Reset() {
+	*x = RequiredProto3OptionalScalarIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3OptionalScalarIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3OptionalScalarIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3OptionalScalarIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3OptionalScalarIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3OptionalScalarIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RequiredProto3OptionalScalarIgnoreAlways) GetVal() string {
 	if x != nil && x.Val != nil {
 		return *x.Val
 	}
@@ -133,7 +221,7 @@ type RequiredProto3Message struct {
 
 func (x *RequiredProto3Message) Reset() {
 	*x = RequiredProto3Message{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -145,7 +233,7 @@ func (x *RequiredProto3Message) String() string {
 func (*RequiredProto3Message) ProtoMessage() {}
 
 func (x *RequiredProto3Message) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -158,10 +246,54 @@ func (x *RequiredProto3Message) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3Message.ProtoReflect.Descriptor instead.
 func (*RequiredProto3Message) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{2}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RequiredProto3Message) GetVal() *RequiredProto3Message_Msg {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto3MessageIgnoreAlways struct {
+	state         protoimpl.MessageState                 `protogen:"open.v1"`
+	Val           *RequiredProto3MessageIgnoreAlways_Msg `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3MessageIgnoreAlways) Reset() {
+	*x = RequiredProto3MessageIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3MessageIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3MessageIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3MessageIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3MessageIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3MessageIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RequiredProto3MessageIgnoreAlways) GetVal() *RequiredProto3MessageIgnoreAlways_Msg {
 	if x != nil {
 		return x.Val
 	}
@@ -181,7 +313,7 @@ type RequiredProto3OneOf struct {
 
 func (x *RequiredProto3OneOf) Reset() {
 	*x = RequiredProto3OneOf{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -193,7 +325,7 @@ func (x *RequiredProto3OneOf) String() string {
 func (*RequiredProto3OneOf) ProtoMessage() {}
 
 func (x *RequiredProto3OneOf) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -206,7 +338,7 @@ func (x *RequiredProto3OneOf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3OneOf.ProtoReflect.Descriptor instead.
 func (*RequiredProto3OneOf) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{3}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RequiredProto3OneOf) GetVal() isRequiredProto3OneOf_Val {
@@ -250,6 +382,88 @@ func (*RequiredProto3OneOf_A) isRequiredProto3OneOf_Val() {}
 
 func (*RequiredProto3OneOf_B) isRequiredProto3OneOf_Val() {}
 
+type RequiredProto3OneOfIgnoreAlways struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Val:
+	//
+	//	*RequiredProto3OneOfIgnoreAlways_A
+	//	*RequiredProto3OneOfIgnoreAlways_B
+	Val           isRequiredProto3OneOfIgnoreAlways_Val `protobuf_oneof:"val"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3OneOfIgnoreAlways) Reset() {
+	*x = RequiredProto3OneOfIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3OneOfIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3OneOfIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3OneOfIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3OneOfIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3OneOfIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *RequiredProto3OneOfIgnoreAlways) GetVal() isRequiredProto3OneOfIgnoreAlways_Val {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+func (x *RequiredProto3OneOfIgnoreAlways) GetA() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredProto3OneOfIgnoreAlways_A); ok {
+			return x.A
+		}
+	}
+	return ""
+}
+
+func (x *RequiredProto3OneOfIgnoreAlways) GetB() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredProto3OneOfIgnoreAlways_B); ok {
+			return x.B
+		}
+	}
+	return ""
+}
+
+type isRequiredProto3OneOfIgnoreAlways_Val interface {
+	isRequiredProto3OneOfIgnoreAlways_Val()
+}
+
+type RequiredProto3OneOfIgnoreAlways_A struct {
+	A string `protobuf:"bytes,1,opt,name=a,proto3,oneof"`
+}
+
+type RequiredProto3OneOfIgnoreAlways_B struct {
+	B string `protobuf:"bytes,2,opt,name=b,proto3,oneof"`
+}
+
+func (*RequiredProto3OneOfIgnoreAlways_A) isRequiredProto3OneOfIgnoreAlways_Val() {}
+
+func (*RequiredProto3OneOfIgnoreAlways_B) isRequiredProto3OneOfIgnoreAlways_Val() {}
+
 type RequiredProto3Repeated struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           []string               `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty"`
@@ -259,7 +473,7 @@ type RequiredProto3Repeated struct {
 
 func (x *RequiredProto3Repeated) Reset() {
 	*x = RequiredProto3Repeated{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -271,7 +485,7 @@ func (x *RequiredProto3Repeated) String() string {
 func (*RequiredProto3Repeated) ProtoMessage() {}
 
 func (x *RequiredProto3Repeated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -284,10 +498,54 @@ func (x *RequiredProto3Repeated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3Repeated.ProtoReflect.Descriptor instead.
 func (*RequiredProto3Repeated) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{4}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *RequiredProto3Repeated) GetVal() []string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto3RepeatedIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           []string               `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3RepeatedIgnoreAlways) Reset() {
+	*x = RequiredProto3RepeatedIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3RepeatedIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3RepeatedIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3RepeatedIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3RepeatedIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3RepeatedIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *RequiredProto3RepeatedIgnoreAlways) GetVal() []string {
 	if x != nil {
 		return x.Val
 	}
@@ -303,7 +561,7 @@ type RequiredProto3Map struct {
 
 func (x *RequiredProto3Map) Reset() {
 	*x = RequiredProto3Map{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -315,7 +573,7 @@ func (x *RequiredProto3Map) String() string {
 func (*RequiredProto3Map) ProtoMessage() {}
 
 func (x *RequiredProto3Map) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -328,10 +586,54 @@ func (x *RequiredProto3Map) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3Map.ProtoReflect.Descriptor instead.
 func (*RequiredProto3Map) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{5}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *RequiredProto3Map) GetVal() map[string]string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto3MapIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           map[string]string      `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3MapIgnoreAlways) Reset() {
+	*x = RequiredProto3MapIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3MapIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3MapIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredProto3MapIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3MapIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredProto3MapIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *RequiredProto3MapIgnoreAlways) GetVal() map[string]string {
 	if x != nil {
 		return x.Val
 	}
@@ -347,7 +649,7 @@ type RequiredProto3Message_Msg struct {
 
 func (x *RequiredProto3Message_Msg) Reset() {
 	*x = RequiredProto3Message_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -359,7 +661,7 @@ func (x *RequiredProto3Message_Msg) String() string {
 func (*RequiredProto3Message_Msg) ProtoMessage() {}
 
 func (x *RequiredProto3Message_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -372,10 +674,54 @@ func (x *RequiredProto3Message_Msg) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredProto3Message_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredProto3Message_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{2, 0}
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{4, 0}
 }
 
 func (x *RequiredProto3Message_Msg) GetVal() string {
+	if x != nil {
+		return x.Val
+	}
+	return ""
+}
+
+type RequiredProto3MessageIgnoreAlways_Msg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3MessageIgnoreAlways_Msg) Reset() {
+	*x = RequiredProto3MessageIgnoreAlways_Msg{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3MessageIgnoreAlways_Msg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3MessageIgnoreAlways_Msg) ProtoMessage() {}
+
+func (x *RequiredProto3MessageIgnoreAlways_Msg) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3MessageIgnoreAlways_Msg.ProtoReflect.Descriptor instead.
+func (*RequiredProto3MessageIgnoreAlways_Msg) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{5, 0}
+}
+
+func (x *RequiredProto3MessageIgnoreAlways_Msg) GetVal() string {
 	if x != nil {
 		return x.Val
 	}
@@ -388,22 +734,42 @@ const file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc = 
 	"\n" +
 	":buf/validate/conformance/cases/required_field_proto3.proto\x12\x1ebuf.validate.conformance.cases\x1a\x1bbuf/validate/validate.proto\"0\n" +
 	"\x14RequiredProto3Scalar\x12\x18\n" +
-	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"E\n" +
+	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"?\n" +
+	" RequiredProto3ScalarIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"E\n" +
 	"\x1cRequiredProto3OptionalScalar\x12\x1d\n" +
 	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01H\x00R\x03val\x88\x01\x01B\x06\n" +
+	"\x04_val\"T\n" +
+	"(RequiredProto3OptionalScalarIgnoreAlways\x12 \n" +
+	"\x03val\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03H\x00R\x03val\x88\x01\x01B\x06\n" +
 	"\x04_val\"\x85\x01\n" +
 	"\x15RequiredProto3Message\x12S\n" +
 	"\x03val\x18\x01 \x01(\v29.buf.validate.conformance.cases.RequiredProto3Message.MsgB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a\x17\n" +
+	"\x03Msg\x12\x10\n" +
+	"\x03val\x18\x01 \x01(\tR\x03val\"\xa0\x01\n" +
+	"!RequiredProto3MessageIgnoreAlways\x12b\n" +
+	"\x03val\x18\x01 \x01(\v2E.buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.MsgB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a\x17\n" +
 	"\x03Msg\x12\x10\n" +
 	"\x03val\x18\x01 \x01(\tR\x03val\"D\n" +
 	"\x13RequiredProto3OneOf\x12\x16\n" +
 	"\x01a\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01H\x00R\x01a\x12\x0e\n" +
 	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
+	"\x03val\"S\n" +
+	"\x1fRequiredProto3OneOfIgnoreAlways\x12\x19\n" +
+	"\x01a\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03H\x00R\x01a\x12\x0e\n" +
+	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
 	"\x03val\"2\n" +
 	"\x16RequiredProto3Repeated\x12\x18\n" +
-	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"\xa1\x01\n" +
+	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"A\n" +
+	"\"RequiredProto3RepeatedIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x03(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"\xa1\x01\n" +
 	"\x11RequiredProto3Map\x12T\n" +
 	"\x03val\x18\x01 \x03(\v2:.buf.validate.conformance.cases.RequiredProto3Map.ValEntryB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a6\n" +
+	"\bValEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbc\x01\n" +
+	"\x1dRequiredProto3MapIgnoreAlways\x12c\n" +
+	"\x03val\x18\x01 \x03(\v2F.buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntryB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a6\n" +
 	"\bValEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\xaf\x02\n" +
@@ -421,25 +787,35 @@ func file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP
 	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescData
 }
 
-var file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_buf_validate_conformance_cases_required_field_proto3_proto_goTypes = []any{
-	(*RequiredProto3Scalar)(nil),         // 0: buf.validate.conformance.cases.RequiredProto3Scalar
-	(*RequiredProto3OptionalScalar)(nil), // 1: buf.validate.conformance.cases.RequiredProto3OptionalScalar
-	(*RequiredProto3Message)(nil),        // 2: buf.validate.conformance.cases.RequiredProto3Message
-	(*RequiredProto3OneOf)(nil),          // 3: buf.validate.conformance.cases.RequiredProto3OneOf
-	(*RequiredProto3Repeated)(nil),       // 4: buf.validate.conformance.cases.RequiredProto3Repeated
-	(*RequiredProto3Map)(nil),            // 5: buf.validate.conformance.cases.RequiredProto3Map
-	(*RequiredProto3Message_Msg)(nil),    // 6: buf.validate.conformance.cases.RequiredProto3Message.Msg
-	nil,                                  // 7: buf.validate.conformance.cases.RequiredProto3Map.ValEntry
+	(*RequiredProto3Scalar)(nil),                     // 0: buf.validate.conformance.cases.RequiredProto3Scalar
+	(*RequiredProto3ScalarIgnoreAlways)(nil),         // 1: buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways
+	(*RequiredProto3OptionalScalar)(nil),             // 2: buf.validate.conformance.cases.RequiredProto3OptionalScalar
+	(*RequiredProto3OptionalScalarIgnoreAlways)(nil), // 3: buf.validate.conformance.cases.RequiredProto3OptionalScalarIgnoreAlways
+	(*RequiredProto3Message)(nil),                    // 4: buf.validate.conformance.cases.RequiredProto3Message
+	(*RequiredProto3MessageIgnoreAlways)(nil),        // 5: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways
+	(*RequiredProto3OneOf)(nil),                      // 6: buf.validate.conformance.cases.RequiredProto3OneOf
+	(*RequiredProto3OneOfIgnoreAlways)(nil),          // 7: buf.validate.conformance.cases.RequiredProto3OneOfIgnoreAlways
+	(*RequiredProto3Repeated)(nil),                   // 8: buf.validate.conformance.cases.RequiredProto3Repeated
+	(*RequiredProto3RepeatedIgnoreAlways)(nil),       // 9: buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways
+	(*RequiredProto3Map)(nil),                        // 10: buf.validate.conformance.cases.RequiredProto3Map
+	(*RequiredProto3MapIgnoreAlways)(nil),            // 11: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways
+	(*RequiredProto3Message_Msg)(nil),                // 12: buf.validate.conformance.cases.RequiredProto3Message.Msg
+	(*RequiredProto3MessageIgnoreAlways_Msg)(nil),    // 13: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
+	nil, // 14: buf.validate.conformance.cases.RequiredProto3Map.ValEntry
+	nil, // 15: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
 }
 var file_buf_validate_conformance_cases_required_field_proto3_proto_depIdxs = []int32{
-	6, // 0: buf.validate.conformance.cases.RequiredProto3Message.val:type_name -> buf.validate.conformance.cases.RequiredProto3Message.Msg
-	7, // 1: buf.validate.conformance.cases.RequiredProto3Map.val:type_name -> buf.validate.conformance.cases.RequiredProto3Map.ValEntry
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	12, // 0: buf.validate.conformance.cases.RequiredProto3Message.val:type_name -> buf.validate.conformance.cases.RequiredProto3Message.Msg
+	13, // 1: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
+	14, // 2: buf.validate.conformance.cases.RequiredProto3Map.val:type_name -> buf.validate.conformance.cases.RequiredProto3Map.ValEntry
+	15, // 3: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
+	4,  // [4:4] is the sub-list for method output_type
+	4,  // [4:4] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_buf_validate_conformance_cases_required_field_proto3_proto_init() }
@@ -447,10 +823,15 @@ func file_buf_validate_conformance_cases_required_field_proto3_proto_init() {
 	if File_buf_validate_conformance_cases_required_field_proto3_proto != nil {
 		return
 	}
-	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[1].OneofWrappers = []any{}
-	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3].OneofWrappers = []any{
+	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[2].OneofWrappers = []any{}
+	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[3].OneofWrappers = []any{}
+	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[6].OneofWrappers = []any{
 		(*RequiredProto3OneOf_A)(nil),
 		(*RequiredProto3OneOf_B)(nil),
+	}
+	file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[7].OneofWrappers = []any{
+		(*RequiredProto3OneOfIgnoreAlways_A)(nil),
+		(*RequiredProto3OneOfIgnoreAlways_B)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -458,7 +839,7 @@ func file_buf_validate_conformance_cases_required_field_proto3_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc), len(file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/tools/internal/gen/buf/validate/conformance/cases/required_field_proto_editions.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/required_field_proto_editions.pb.go
@@ -80,6 +80,50 @@ func (x *RequiredEditionsScalarExplicitPresence) GetVal() string {
 	return ""
 }
 
+type RequiredEditionsScalarExplicitPresenceIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsScalarExplicitPresenceIgnoreAlways) Reset() {
+	*x = RequiredEditionsScalarExplicitPresenceIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsScalarExplicitPresenceIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsScalarExplicitPresenceIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsScalarExplicitPresenceIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsScalarExplicitPresenceIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsScalarExplicitPresenceIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RequiredEditionsScalarExplicitPresenceIgnoreAlways) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
 type RequiredEditionsScalarExplicitPresenceDefault struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           *string                `protobuf:"bytes,1,opt,name=val,def=foo" json:"val,omitempty"`
@@ -94,7 +138,7 @@ const (
 
 func (x *RequiredEditionsScalarExplicitPresenceDefault) Reset() {
 	*x = RequiredEditionsScalarExplicitPresenceDefault{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -106,7 +150,7 @@ func (x *RequiredEditionsScalarExplicitPresenceDefault) String() string {
 func (*RequiredEditionsScalarExplicitPresenceDefault) ProtoMessage() {}
 
 func (x *RequiredEditionsScalarExplicitPresenceDefault) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[1]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -119,7 +163,7 @@ func (x *RequiredEditionsScalarExplicitPresenceDefault) ProtoReflect() protorefl
 
 // Deprecated: Use RequiredEditionsScalarExplicitPresenceDefault.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsScalarExplicitPresenceDefault) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{1}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RequiredEditionsScalarExplicitPresenceDefault) GetVal() string {
@@ -127,6 +171,55 @@ func (x *RequiredEditionsScalarExplicitPresenceDefault) GetVal() string {
 		return *x.Val
 	}
 	return Default_RequiredEditionsScalarExplicitPresenceDefault_Val
+}
+
+type RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val,def=foo" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+// Default values for RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways fields.
+const (
+	Default_RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways_Val = string("foo")
+)
+
+func (x *RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) Reset() {
+	*x = RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return Default_RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways_Val
 }
 
 type RequiredEditionsScalarImplicitPresence struct {
@@ -138,7 +231,7 @@ type RequiredEditionsScalarImplicitPresence struct {
 
 func (x *RequiredEditionsScalarImplicitPresence) Reset() {
 	*x = RequiredEditionsScalarImplicitPresence{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -150,7 +243,7 @@ func (x *RequiredEditionsScalarImplicitPresence) String() string {
 func (*RequiredEditionsScalarImplicitPresence) ProtoMessage() {}
 
 func (x *RequiredEditionsScalarImplicitPresence) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[2]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -163,10 +256,54 @@ func (x *RequiredEditionsScalarImplicitPresence) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use RequiredEditionsScalarImplicitPresence.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsScalarImplicitPresence) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{2}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RequiredEditionsScalarImplicitPresence) GetVal() string {
+	if x != nil {
+		return x.Val
+	}
+	return ""
+}
+
+type RequiredEditionsScalarImplicitPresenceIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           string                 `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsScalarImplicitPresenceIgnoreAlways) Reset() {
+	*x = RequiredEditionsScalarImplicitPresenceIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsScalarImplicitPresenceIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsScalarImplicitPresenceIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsScalarImplicitPresenceIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsScalarImplicitPresenceIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsScalarImplicitPresenceIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RequiredEditionsScalarImplicitPresenceIgnoreAlways) GetVal() string {
 	if x != nil {
 		return x.Val
 	}
@@ -182,7 +319,7 @@ type RequiredEditionsScalarLegacyRequired struct {
 
 func (x *RequiredEditionsScalarLegacyRequired) Reset() {
 	*x = RequiredEditionsScalarLegacyRequired{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -194,7 +331,7 @@ func (x *RequiredEditionsScalarLegacyRequired) String() string {
 func (*RequiredEditionsScalarLegacyRequired) ProtoMessage() {}
 
 func (x *RequiredEditionsScalarLegacyRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -207,7 +344,7 @@ func (x *RequiredEditionsScalarLegacyRequired) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use RequiredEditionsScalarLegacyRequired.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsScalarLegacyRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{3}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RequiredEditionsScalarLegacyRequired) GetVal() string {
@@ -226,7 +363,7 @@ type RequiredEditionsMessageExplicitPresence struct {
 
 func (x *RequiredEditionsMessageExplicitPresence) Reset() {
 	*x = RequiredEditionsMessageExplicitPresence{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -238,7 +375,7 @@ func (x *RequiredEditionsMessageExplicitPresence) String() string {
 func (*RequiredEditionsMessageExplicitPresence) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageExplicitPresence) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -251,10 +388,54 @@ func (x *RequiredEditionsMessageExplicitPresence) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use RequiredEditionsMessageExplicitPresence.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageExplicitPresence) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{4}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RequiredEditionsMessageExplicitPresence) GetVal() *RequiredEditionsMessageExplicitPresence_Msg {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredEditionsMessageExplicitPresenceIgnoreAlways struct {
+	state         protoimpl.MessageState                                   `protogen:"open.v1"`
+	Val           *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways) Reset() {
+	*x = RequiredEditionsMessageExplicitPresenceIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsMessageExplicitPresenceIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsMessageExplicitPresenceIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsMessageExplicitPresenceIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways) GetVal() *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg {
 	if x != nil {
 		return x.Val
 	}
@@ -270,7 +451,7 @@ type RequiredEditionsMessageExplicitPresenceDelimited struct {
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited) Reset() {
 	*x = RequiredEditionsMessageExplicitPresenceDelimited{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -282,7 +463,7 @@ func (x *RequiredEditionsMessageExplicitPresenceDelimited) String() string {
 func (*RequiredEditionsMessageExplicitPresenceDelimited) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -295,10 +476,54 @@ func (x *RequiredEditionsMessageExplicitPresenceDelimited) ProtoReflect() protor
 
 // Deprecated: Use RequiredEditionsMessageExplicitPresenceDelimited.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageExplicitPresenceDelimited) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{5}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited) GetVal() *RequiredEditionsMessageExplicitPresenceDelimited_Msg {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways struct {
+	state         protoimpl.MessageState                                            `protogen:"open.v1"`
+	Val           *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg `protobuf:"group,1,opt,name=Msg,json=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) Reset() {
+	*x = RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways) GetVal() *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg {
 	if x != nil {
 		return x.Val
 	}
@@ -314,7 +539,7 @@ type RequiredEditionsMessageLegacyRequired struct {
 
 func (x *RequiredEditionsMessageLegacyRequired) Reset() {
 	*x = RequiredEditionsMessageLegacyRequired{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -326,7 +551,7 @@ func (x *RequiredEditionsMessageLegacyRequired) String() string {
 func (*RequiredEditionsMessageLegacyRequired) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageLegacyRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -339,7 +564,7 @@ func (x *RequiredEditionsMessageLegacyRequired) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use RequiredEditionsMessageLegacyRequired.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageLegacyRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{6}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RequiredEditionsMessageLegacyRequired) GetVal() *RequiredEditionsMessageLegacyRequired_Msg {
@@ -358,7 +583,7 @@ type RequiredEditionsMessageLegacyRequiredDelimited struct {
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited) Reset() {
 	*x = RequiredEditionsMessageLegacyRequiredDelimited{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -370,7 +595,7 @@ func (x *RequiredEditionsMessageLegacyRequiredDelimited) String() string {
 func (*RequiredEditionsMessageLegacyRequiredDelimited) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -383,7 +608,7 @@ func (x *RequiredEditionsMessageLegacyRequiredDelimited) ProtoReflect() protoref
 
 // Deprecated: Use RequiredEditionsMessageLegacyRequiredDelimited.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageLegacyRequiredDelimited) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{7}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited) GetVal() *RequiredEditionsMessageLegacyRequiredDelimited_Msg {
@@ -406,7 +631,7 @@ type RequiredEditionsOneof struct {
 
 func (x *RequiredEditionsOneof) Reset() {
 	*x = RequiredEditionsOneof{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[8]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -418,7 +643,7 @@ func (x *RequiredEditionsOneof) String() string {
 func (*RequiredEditionsOneof) ProtoMessage() {}
 
 func (x *RequiredEditionsOneof) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[8]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -431,7 +656,7 @@ func (x *RequiredEditionsOneof) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredEditionsOneof.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsOneof) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{8}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *RequiredEditionsOneof) GetVal() isRequiredEditionsOneof_Val {
@@ -475,6 +700,88 @@ func (*RequiredEditionsOneof_A) isRequiredEditionsOneof_Val() {}
 
 func (*RequiredEditionsOneof_B) isRequiredEditionsOneof_Val() {}
 
+type RequiredEditionsOneofIgnoreAlways struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Val:
+	//
+	//	*RequiredEditionsOneofIgnoreAlways_A
+	//	*RequiredEditionsOneofIgnoreAlways_B
+	Val           isRequiredEditionsOneofIgnoreAlways_Val `protobuf_oneof:"val"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsOneofIgnoreAlways) Reset() {
+	*x = RequiredEditionsOneofIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsOneofIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsOneofIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsOneofIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsOneofIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsOneofIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RequiredEditionsOneofIgnoreAlways) GetVal() isRequiredEditionsOneofIgnoreAlways_Val {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+func (x *RequiredEditionsOneofIgnoreAlways) GetA() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredEditionsOneofIgnoreAlways_A); ok {
+			return x.A
+		}
+	}
+	return ""
+}
+
+func (x *RequiredEditionsOneofIgnoreAlways) GetB() string {
+	if x != nil {
+		if x, ok := x.Val.(*RequiredEditionsOneofIgnoreAlways_B); ok {
+			return x.B
+		}
+	}
+	return ""
+}
+
+type isRequiredEditionsOneofIgnoreAlways_Val interface {
+	isRequiredEditionsOneofIgnoreAlways_Val()
+}
+
+type RequiredEditionsOneofIgnoreAlways_A struct {
+	A string `protobuf:"bytes,1,opt,name=a,oneof"`
+}
+
+type RequiredEditionsOneofIgnoreAlways_B struct {
+	B string `protobuf:"bytes,2,opt,name=b,oneof"`
+}
+
+func (*RequiredEditionsOneofIgnoreAlways_A) isRequiredEditionsOneofIgnoreAlways_Val() {}
+
+func (*RequiredEditionsOneofIgnoreAlways_B) isRequiredEditionsOneofIgnoreAlways_Val() {}
+
 type RequiredEditionsRepeated struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           []string               `protobuf:"bytes,1,rep,name=val" json:"val,omitempty"`
@@ -484,7 +791,7 @@ type RequiredEditionsRepeated struct {
 
 func (x *RequiredEditionsRepeated) Reset() {
 	*x = RequiredEditionsRepeated{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[9]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -496,7 +803,7 @@ func (x *RequiredEditionsRepeated) String() string {
 func (*RequiredEditionsRepeated) ProtoMessage() {}
 
 func (x *RequiredEditionsRepeated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[9]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -509,10 +816,54 @@ func (x *RequiredEditionsRepeated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredEditionsRepeated.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsRepeated) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{9}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RequiredEditionsRepeated) GetVal() []string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredEditionsRepeatedIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           []string               `protobuf:"bytes,1,rep,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsRepeatedIgnoreAlways) Reset() {
+	*x = RequiredEditionsRepeatedIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsRepeatedIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsRepeatedIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsRepeatedIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsRepeatedIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsRepeatedIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *RequiredEditionsRepeatedIgnoreAlways) GetVal() []string {
 	if x != nil {
 		return x.Val
 	}
@@ -528,7 +879,7 @@ type RequiredEditionsRepeatedExpanded struct {
 
 func (x *RequiredEditionsRepeatedExpanded) Reset() {
 	*x = RequiredEditionsRepeatedExpanded{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[10]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -540,7 +891,7 @@ func (x *RequiredEditionsRepeatedExpanded) String() string {
 func (*RequiredEditionsRepeatedExpanded) ProtoMessage() {}
 
 func (x *RequiredEditionsRepeatedExpanded) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[10]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -553,10 +904,54 @@ func (x *RequiredEditionsRepeatedExpanded) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredEditionsRepeatedExpanded.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsRepeatedExpanded) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{10}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *RequiredEditionsRepeatedExpanded) GetVal() []string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredEditionsRepeatedExpandedIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           []string               `protobuf:"bytes,1,rep,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsRepeatedExpandedIgnoreAlways) Reset() {
+	*x = RequiredEditionsRepeatedExpandedIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsRepeatedExpandedIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsRepeatedExpandedIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsRepeatedExpandedIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsRepeatedExpandedIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsRepeatedExpandedIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *RequiredEditionsRepeatedExpandedIgnoreAlways) GetVal() []string {
 	if x != nil {
 		return x.Val
 	}
@@ -572,7 +967,7 @@ type RequiredEditionsMap struct {
 
 func (x *RequiredEditionsMap) Reset() {
 	*x = RequiredEditionsMap{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[11]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -584,7 +979,7 @@ func (x *RequiredEditionsMap) String() string {
 func (*RequiredEditionsMap) ProtoMessage() {}
 
 func (x *RequiredEditionsMap) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[11]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -597,10 +992,54 @@ func (x *RequiredEditionsMap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RequiredEditionsMap.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMap) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{11}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RequiredEditionsMap) GetVal() map[string]string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredEditionsMapIgnoreAlways struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           map[string]string      `protobuf:"bytes,1,rep,name=val" json:"val,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsMapIgnoreAlways) Reset() {
+	*x = RequiredEditionsMapIgnoreAlways{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsMapIgnoreAlways) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsMapIgnoreAlways) ProtoMessage() {}
+
+func (x *RequiredEditionsMapIgnoreAlways) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsMapIgnoreAlways.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsMapIgnoreAlways) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *RequiredEditionsMapIgnoreAlways) GetVal() map[string]string {
 	if x != nil {
 		return x.Val
 	}
@@ -616,7 +1055,7 @@ type RequiredEditionsMessageExplicitPresence_Msg struct {
 
 func (x *RequiredEditionsMessageExplicitPresence_Msg) Reset() {
 	*x = RequiredEditionsMessageExplicitPresence_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -628,7 +1067,7 @@ func (x *RequiredEditionsMessageExplicitPresence_Msg) String() string {
 func (*RequiredEditionsMessageExplicitPresence_Msg) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageExplicitPresence_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -641,10 +1080,54 @@ func (x *RequiredEditionsMessageExplicitPresence_Msg) ProtoReflect() protoreflec
 
 // Deprecated: Use RequiredEditionsMessageExplicitPresence_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageExplicitPresence_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{4, 0}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{7, 0}
 }
 
 func (x *RequiredEditionsMessageExplicitPresence_Msg) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
+type RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) Reset() {
+	*x = RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) ProtoMessage() {}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{8, 0}
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg) GetVal() string {
 	if x != nil && x.Val != nil {
 		return *x.Val
 	}
@@ -660,7 +1143,7 @@ type RequiredEditionsMessageExplicitPresenceDelimited_Msg struct {
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited_Msg) Reset() {
 	*x = RequiredEditionsMessageExplicitPresenceDelimited_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -672,7 +1155,7 @@ func (x *RequiredEditionsMessageExplicitPresenceDelimited_Msg) String() string {
 func (*RequiredEditionsMessageExplicitPresenceDelimited_Msg) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -685,10 +1168,54 @@ func (x *RequiredEditionsMessageExplicitPresenceDelimited_Msg) ProtoReflect() pr
 
 // Deprecated: Use RequiredEditionsMessageExplicitPresenceDelimited_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageExplicitPresenceDelimited_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{5, 0}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{9, 0}
 }
 
 func (x *RequiredEditionsMessageExplicitPresenceDelimited_Msg) GetVal() string {
+	if x != nil && x.Val != nil {
+		return *x.Val
+	}
+	return ""
+}
+
+type RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           *string                `protobuf:"bytes,1,opt,name=val" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) Reset() {
+	*x = RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) ProtoMessage() {}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg.ProtoReflect.Descriptor instead.
+func (*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{10, 0}
+}
+
+func (x *RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg) GetVal() string {
 	if x != nil && x.Val != nil {
 		return *x.Val
 	}
@@ -704,7 +1231,7 @@ type RequiredEditionsMessageLegacyRequired_Msg struct {
 
 func (x *RequiredEditionsMessageLegacyRequired_Msg) Reset() {
 	*x = RequiredEditionsMessageLegacyRequired_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[14]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +1243,7 @@ func (x *RequiredEditionsMessageLegacyRequired_Msg) String() string {
 func (*RequiredEditionsMessageLegacyRequired_Msg) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageLegacyRequired_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[14]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +1256,7 @@ func (x *RequiredEditionsMessageLegacyRequired_Msg) ProtoReflect() protoreflect.
 
 // Deprecated: Use RequiredEditionsMessageLegacyRequired_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageLegacyRequired_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{6, 0}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{11, 0}
 }
 
 func (x *RequiredEditionsMessageLegacyRequired_Msg) GetVal() string {
@@ -748,7 +1275,7 @@ type RequiredEditionsMessageLegacyRequiredDelimited_Msg struct {
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited_Msg) Reset() {
 	*x = RequiredEditionsMessageLegacyRequiredDelimited_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[15]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -760,7 +1287,7 @@ func (x *RequiredEditionsMessageLegacyRequiredDelimited_Msg) String() string {
 func (*RequiredEditionsMessageLegacyRequiredDelimited_Msg) ProtoMessage() {}
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[15]
+	mi := &file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -773,7 +1300,7 @@ func (x *RequiredEditionsMessageLegacyRequiredDelimited_Msg) ProtoReflect() prot
 
 // Deprecated: Use RequiredEditionsMessageLegacyRequiredDelimited_Msg.ProtoReflect.Descriptor instead.
 func (*RequiredEditionsMessageLegacyRequiredDelimited_Msg) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{7, 0}
+	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescGZIP(), []int{12, 0}
 }
 
 func (x *RequiredEditionsMessageLegacyRequiredDelimited_Msg) GetVal() string {
@@ -789,19 +1316,33 @@ const file_buf_validate_conformance_cases_required_field_proto_editions_proto_ra
 	"\n" +
 	"Bbuf/validate/conformance/cases/required_field_proto_editions.proto\x12\x1ebuf.validate.conformance.cases\x1a\x1bbuf/validate/validate.proto\"B\n" +
 	"&RequiredEditionsScalarExplicitPresence\x12\x18\n" +
-	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"N\n" +
+	"\x03val\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"Q\n" +
+	"2RequiredEditionsScalarExplicitPresenceIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"N\n" +
 	"-RequiredEditionsScalarExplicitPresenceDefault\x12\x1d\n" +
-	"\x03val\x18\x01 \x01(\t:\x03fooB\x06\xbaH\x03\xc8\x01\x01R\x03val\"G\n" +
+	"\x03val\x18\x01 \x01(\t:\x03fooB\x06\xbaH\x03\xc8\x01\x01R\x03val\"]\n" +
+	"9RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways\x12 \n" +
+	"\x03val\x18\x01 \x01(\t:\x03fooB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"G\n" +
 	"&RequiredEditionsScalarImplicitPresence\x12\x1d\n" +
-	"\x03val\x18\x01 \x01(\tB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02\b\x02R\x03val\"E\n" +
+	"\x03val\x18\x01 \x01(\tB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02\b\x02R\x03val\"V\n" +
+	"2RequiredEditionsScalarImplicitPresenceIgnoreAlways\x12 \n" +
+	"\x03val\x18\x01 \x01(\tB\x0e\xbaH\x06\xc8\x01\x01\xd8\x01\x03\xaa\x01\x02\b\x02R\x03val\"E\n" +
 	"$RequiredEditionsScalarLegacyRequired\x12\x1d\n" +
 	"\x03val\x18\x01 \x01(\tB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02\b\x03R\x03val\"\xa9\x01\n" +
 	"'RequiredEditionsMessageExplicitPresence\x12e\n" +
 	"\x03val\x18\x01 \x01(\v2K.buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.MsgB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a\x17\n" +
 	"\x03Msg\x12\x10\n" +
+	"\x03val\x18\x01 \x01(\tR\x03val\"\xc4\x01\n" +
+	"3RequiredEditionsMessageExplicitPresenceIgnoreAlways\x12t\n" +
+	"\x03val\x18\x01 \x01(\v2W.buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.MsgB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a\x17\n" +
+	"\x03Msg\x12\x10\n" +
 	"\x03val\x18\x01 \x01(\tR\x03val\"\xc0\x01\n" +
 	"0RequiredEditionsMessageExplicitPresenceDelimited\x12s\n" +
 	"\x03val\x18\x01 \x01(\v2T.buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.MsgB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02(\x02R\x03val\x1a\x17\n" +
+	"\x03Msg\x12\x10\n" +
+	"\x03val\x18\x01 \x01(\tR\x03val\"\xdc\x01\n" +
+	"<RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways\x12\x82\x01\n" +
+	"\x03val\x18\x01 \x01(\v2`.buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.MsgB\x0e\xbaH\x06\xc8\x01\x01\xd8\x01\x03\xaa\x01\x02(\x02R\x03val\x1a\x17\n" +
 	"\x03Msg\x12\x10\n" +
 	"\x03val\x18\x01 \x01(\tR\x03val\"\xaa\x01\n" +
 	"%RequiredEditionsMessageLegacyRequired\x12h\n" +
@@ -815,13 +1356,26 @@ const file_buf_validate_conformance_cases_required_field_proto_editions_proto_ra
 	"\x15RequiredEditionsOneof\x12\x16\n" +
 	"\x01a\x18\x01 \x01(\tB\x06\xbaH\x03\xc8\x01\x01H\x00R\x01a\x12\x0e\n" +
 	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
+	"\x03val\"U\n" +
+	"!RequiredEditionsOneofIgnoreAlways\x12\x19\n" +
+	"\x01a\x18\x01 \x01(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03H\x00R\x01a\x12\x0e\n" +
+	"\x01b\x18\x02 \x01(\tH\x00R\x01bB\x05\n" +
 	"\x03val\"4\n" +
 	"\x18RequiredEditionsRepeated\x12\x18\n" +
-	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"A\n" +
+	"\x03val\x18\x01 \x03(\tB\x06\xbaH\x03\xc8\x01\x01R\x03val\"C\n" +
+	"$RequiredEditionsRepeatedIgnoreAlways\x12\x1b\n" +
+	"\x03val\x18\x01 \x03(\tB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\"A\n" +
 	" RequiredEditionsRepeatedExpanded\x12\x1d\n" +
-	"\x03val\x18\x01 \x03(\tB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02\x18\x02R\x03val\"\xa5\x01\n" +
+	"\x03val\x18\x01 \x03(\tB\v\xbaH\x03\xc8\x01\x01\xaa\x01\x02\x18\x02R\x03val\"P\n" +
+	",RequiredEditionsRepeatedExpandedIgnoreAlways\x12 \n" +
+	"\x03val\x18\x01 \x03(\tB\x0e\xbaH\x06\xc8\x01\x01\xd8\x01\x03\xaa\x01\x02\x18\x02R\x03val\"\xa5\x01\n" +
 	"\x13RequiredEditionsMap\x12V\n" +
 	"\x03val\x18\x01 \x03(\v2<.buf.validate.conformance.cases.RequiredEditionsMap.ValEntryB\x06\xbaH\x03\xc8\x01\x01R\x03val\x1a6\n" +
+	"\bValEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xc0\x01\n" +
+	"\x1fRequiredEditionsMapIgnoreAlways\x12e\n" +
+	"\x03val\x18\x01 \x03(\v2H.buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways.ValEntryB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a6\n" +
 	"\bValEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\xb6\x02\n" +
@@ -839,37 +1393,52 @@ func file_buf_validate_conformance_cases_required_field_proto_editions_proto_raw
 	return file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDescData
 }
 
-var file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_buf_validate_conformance_cases_required_field_proto_editions_proto_goTypes = []any{
-	(*RequiredEditionsScalarExplicitPresence)(nil),               // 0: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresence
-	(*RequiredEditionsScalarExplicitPresenceDefault)(nil),        // 1: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefault
-	(*RequiredEditionsScalarImplicitPresence)(nil),               // 2: buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresence
-	(*RequiredEditionsScalarLegacyRequired)(nil),                 // 3: buf.validate.conformance.cases.RequiredEditionsScalarLegacyRequired
-	(*RequiredEditionsMessageExplicitPresence)(nil),              // 4: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence
-	(*RequiredEditionsMessageExplicitPresenceDelimited)(nil),     // 5: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited
-	(*RequiredEditionsMessageLegacyRequired)(nil),                // 6: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired
-	(*RequiredEditionsMessageLegacyRequiredDelimited)(nil),       // 7: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited
-	(*RequiredEditionsOneof)(nil),                                // 8: buf.validate.conformance.cases.RequiredEditionsOneof
-	(*RequiredEditionsRepeated)(nil),                             // 9: buf.validate.conformance.cases.RequiredEditionsRepeated
-	(*RequiredEditionsRepeatedExpanded)(nil),                     // 10: buf.validate.conformance.cases.RequiredEditionsRepeatedExpanded
-	(*RequiredEditionsMap)(nil),                                  // 11: buf.validate.conformance.cases.RequiredEditionsMap
-	(*RequiredEditionsMessageExplicitPresence_Msg)(nil),          // 12: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.Msg
-	(*RequiredEditionsMessageExplicitPresenceDelimited_Msg)(nil), // 13: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.Msg
-	(*RequiredEditionsMessageLegacyRequired_Msg)(nil),            // 14: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.Msg
-	(*RequiredEditionsMessageLegacyRequiredDelimited_Msg)(nil),   // 15: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.Msg
-	nil, // 16: buf.validate.conformance.cases.RequiredEditionsMap.ValEntry
+	(*RequiredEditionsScalarExplicitPresence)(nil),                           // 0: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresence
+	(*RequiredEditionsScalarExplicitPresenceIgnoreAlways)(nil),               // 1: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways
+	(*RequiredEditionsScalarExplicitPresenceDefault)(nil),                    // 2: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefault
+	(*RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways)(nil),        // 3: buf.validate.conformance.cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways
+	(*RequiredEditionsScalarImplicitPresence)(nil),                           // 4: buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresence
+	(*RequiredEditionsScalarImplicitPresenceIgnoreAlways)(nil),               // 5: buf.validate.conformance.cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways
+	(*RequiredEditionsScalarLegacyRequired)(nil),                             // 6: buf.validate.conformance.cases.RequiredEditionsScalarLegacyRequired
+	(*RequiredEditionsMessageExplicitPresence)(nil),                          // 7: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence
+	(*RequiredEditionsMessageExplicitPresenceIgnoreAlways)(nil),              // 8: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways
+	(*RequiredEditionsMessageExplicitPresenceDelimited)(nil),                 // 9: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited
+	(*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways)(nil),     // 10: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways
+	(*RequiredEditionsMessageLegacyRequired)(nil),                            // 11: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired
+	(*RequiredEditionsMessageLegacyRequiredDelimited)(nil),                   // 12: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited
+	(*RequiredEditionsOneof)(nil),                                            // 13: buf.validate.conformance.cases.RequiredEditionsOneof
+	(*RequiredEditionsOneofIgnoreAlways)(nil),                                // 14: buf.validate.conformance.cases.RequiredEditionsOneofIgnoreAlways
+	(*RequiredEditionsRepeated)(nil),                                         // 15: buf.validate.conformance.cases.RequiredEditionsRepeated
+	(*RequiredEditionsRepeatedIgnoreAlways)(nil),                             // 16: buf.validate.conformance.cases.RequiredEditionsRepeatedIgnoreAlways
+	(*RequiredEditionsRepeatedExpanded)(nil),                                 // 17: buf.validate.conformance.cases.RequiredEditionsRepeatedExpanded
+	(*RequiredEditionsRepeatedExpandedIgnoreAlways)(nil),                     // 18: buf.validate.conformance.cases.RequiredEditionsRepeatedExpandedIgnoreAlways
+	(*RequiredEditionsMap)(nil),                                              // 19: buf.validate.conformance.cases.RequiredEditionsMap
+	(*RequiredEditionsMapIgnoreAlways)(nil),                                  // 20: buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways
+	(*RequiredEditionsMessageExplicitPresence_Msg)(nil),                      // 21: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.Msg
+	(*RequiredEditionsMessageExplicitPresenceIgnoreAlways_Msg)(nil),          // 22: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg
+	(*RequiredEditionsMessageExplicitPresenceDelimited_Msg)(nil),             // 23: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.Msg
+	(*RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways_Msg)(nil), // 24: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg
+	(*RequiredEditionsMessageLegacyRequired_Msg)(nil),                        // 25: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.Msg
+	(*RequiredEditionsMessageLegacyRequiredDelimited_Msg)(nil),               // 26: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.Msg
+	nil, // 27: buf.validate.conformance.cases.RequiredEditionsMap.ValEntry
+	nil, // 28: buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways.ValEntry
 }
 var file_buf_validate_conformance_cases_required_field_proto_editions_proto_depIdxs = []int32{
-	12, // 0: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.Msg
-	13, // 1: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.Msg
-	14, // 2: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.Msg
-	15, // 3: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.Msg
-	16, // 4: buf.validate.conformance.cases.RequiredEditionsMap.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMap.ValEntry
-	5,  // [5:5] is the sub-list for method output_type
-	5,  // [5:5] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	21, // 0: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresence.Msg
+	22, // 1: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways.Msg
+	23, // 2: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimited.Msg
+	24, // 3: buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways.Msg
+	25, // 4: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequired.Msg
+	26, // 5: buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMessageLegacyRequiredDelimited.Msg
+	27, // 6: buf.validate.conformance.cases.RequiredEditionsMap.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMap.ValEntry
+	28, // 7: buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredEditionsMapIgnoreAlways.ValEntry
+	8,  // [8:8] is the sub-list for method output_type
+	8,  // [8:8] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_buf_validate_conformance_cases_required_field_proto_editions_proto_init() }
@@ -877,9 +1446,13 @@ func file_buf_validate_conformance_cases_required_field_proto_editions_proto_ini
 	if File_buf_validate_conformance_cases_required_field_proto_editions_proto != nil {
 		return
 	}
-	file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[8].OneofWrappers = []any{
+	file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[13].OneofWrappers = []any{
 		(*RequiredEditionsOneof_A)(nil),
 		(*RequiredEditionsOneof_B)(nil),
+	}
+	file_buf_validate_conformance_cases_required_field_proto_editions_proto_msgTypes[14].OneofWrappers = []any{
+		(*RequiredEditionsOneofIgnoreAlways_A)(nil),
+		(*RequiredEditionsOneofIgnoreAlways_B)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -887,7 +1460,7 @@ func file_buf_validate_conformance_cases_required_field_proto_editions_proto_ini
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDesc), len(file_buf_validate_conformance_cases_required_field_proto_editions_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   17,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/tools/protovalidate-conformance/internal/cases/cases_required.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_required.go
@@ -40,6 +40,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto2/scalar/optional/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2ScalarOptionalIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto2/scalar/optional_with_default/nonzero": suites.Case{
 			Message:  &cases.RequiredProto2ScalarOptionalDefault{Val: proto.String("bar")},
 			Expected: results.Success(true),
@@ -59,6 +63,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto2/scalar/optional_with_default/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2ScalarOptionalDefaultIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto2/scalar/required/nonzero": suites.Case{
 			Message:  &cases.RequiredProto2ScalarRequired{Val: proto.String("foo")},
@@ -84,6 +92,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto2/message/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2MessageIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto2/oneof/nonzero": suites.Case{
 			Message:  &cases.RequiredProto2Oneof{Val: &cases.RequiredProto2Oneof_A{A: "foo"}},
 			Expected: results.Success(true),
@@ -100,6 +112,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto2/oneof/other_member/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2OneofIgnoreAlways{Val: &cases.RequiredProto2OneofIgnoreAlways_B{B: "foo"}},
+			Expected: results.Success(true),
+		},
 		"proto2/oneof/unset": suites.Case{
 			Message: &cases.RequiredProto2Oneof{},
 			Expected: results.Violations(&validate.Violation{
@@ -107,6 +123,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto2/oneof/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2OneofIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto2/repeated/nonempty": suites.Case{
 			Message:  &cases.RequiredProto2Repeated{Val: []string{"foo"}},
@@ -120,6 +140,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto2/repeated/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2RepeatedIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto2/map/nonempty": suites.Case{
 			Message:  &cases.RequiredProto2Map{Val: map[string]string{"foo": "bar"}},
 			Expected: results.Success(true),
@@ -132,6 +156,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto2/map/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto2MapIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto3/scalar/nonzero": suites.Case{
 			Message:  &cases.RequiredProto3Scalar{Val: "foo"},
 			Expected: results.Success(true),
@@ -143,6 +171,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto3/scalar/zero/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3ScalarIgnoreAlways{Val: ""},
+			Expected: results.Success(true),
 		},
 		"proto3/scalar/optional/nonzero": suites.Case{
 			Message:  &cases.RequiredProto3OptionalScalar{Val: proto.String("foo")},
@@ -160,6 +192,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto3/scalar/optional/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3OptionalScalarIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto3/message/nonzero": suites.Case{
 			Message:  &cases.RequiredProto3Message{Val: &cases.RequiredProto3Message_Msg{Val: "foo"}},
 			Expected: results.Success(true),
@@ -175,6 +211,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto3/message/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3MessageIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto3/oneof/nonzero": suites.Case{
 			Message:  &cases.RequiredProto3OneOf{Val: &cases.RequiredProto3OneOf_A{A: "foo"}},
@@ -192,6 +232,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto3/oneof/other_member/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3OneOfIgnoreAlways{Val: &cases.RequiredProto3OneOfIgnoreAlways_B{B: "foo"}},
+			Expected: results.Success(true),
+		},
 		"proto3/oneof/unset": suites.Case{
 			Message: &cases.RequiredProto3OneOf{},
 			Expected: results.Violations(&validate.Violation{
@@ -199,6 +243,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto3/oneof/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3OneOfIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto3/repeated/nonempty": suites.Case{
 			Message:  &cases.RequiredProto3Repeated{Val: []string{"foo"}},
@@ -212,6 +260,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto3/repeated/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3RepeatedIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto3/map/nonempty": suites.Case{
 			Message:  &cases.RequiredProto3Map{Val: map[string]string{"foo": "bar"}},
 			Expected: results.Success(true),
@@ -223,6 +275,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto3/map/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredProto3MapIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto/2023/scalar/explicit_presence/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsScalarExplicitPresence{Val: proto.String("foo")},
@@ -239,6 +295,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto/2023/scalar/explicit_presence/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsScalarExplicitPresenceIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto/2023/scalar/explicit_presence_with_default/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsScalarExplicitPresenceDefault{Val: proto.String("bar")},
@@ -260,6 +320,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto/2023/scalar/explicit_presence_with_default/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsScalarExplicitPresenceDefaultIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto/2023/scalar/implicit_presence/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsScalarImplicitPresence{Val: "foo"},
 			Expected: results.Success(true),
@@ -271,6 +335,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto/2023/scalar/implicit_presence/zero/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsScalarImplicitPresenceIgnoreAlways{Val: ""},
+			Expected: results.Success(true),
 		},
 		"proto/2023/scalar/legacy_required/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsScalarLegacyRequired{Val: proto.String("foo")},
@@ -296,6 +364,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto/2023/message/explicit_presence/length_prefixed/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsMessageExplicitPresenceIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto/2023/message/explicit_presence/delimited/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsMessageExplicitPresenceDelimited{Val: &cases.RequiredEditionsMessageExplicitPresenceDelimited_Msg{Val: proto.String("foo")}},
 			Expected: results.Success(true),
@@ -311,6 +383,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto/2023/message/explicit_presence/delimited/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsMessageExplicitPresenceDelimitedIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto/2023/message/legacy_required/length_prefixed/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsMessageLegacyRequired{Val: &cases.RequiredEditionsMessageLegacyRequired_Msg{Val: proto.String("foo")}},
@@ -344,6 +420,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto/2023/oneof/other_member/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsOneofIgnoreAlways{Val: &cases.RequiredEditionsOneofIgnoreAlways_B{B: "foo"}},
+			Expected: results.Success(true),
+		},
 		"proto/2023/oneof/unset": suites.Case{
 			Message: &cases.RequiredEditionsOneof{},
 			Expected: results.Violations(&validate.Violation{
@@ -351,6 +431,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto/2023/oneof/unset/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsOneofIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 		"proto/2023/repeated/compact/nonempty": suites.Case{
 			Message:  &cases.RequiredEditionsRepeated{Val: []string{"foo"}},
@@ -364,6 +448,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto/2023/repeated/compact/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsRepeatedIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto/2023/repeated/expanded/nonempty": suites.Case{
 			Message:  &cases.RequiredEditionsRepeatedExpanded{Val: []string{"foo"}},
 			Expected: results.Success(true),
@@ -376,6 +464,10 @@ func requiredSuite() suites.Suite {
 				ConstraintId: proto.String("required"),
 			}),
 		},
+		"proto/2023/repeated/expanded/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsRepeatedExpandedIgnoreAlways{},
+			Expected: results.Success(true),
+		},
 		"proto/2023/map/nonempty": suites.Case{
 			Message:  &cases.RequiredEditionsMap{Val: map[string]string{"foo": "bar"}},
 			Expected: results.Success(true),
@@ -387,6 +479,10 @@ func requiredSuite() suites.Suite {
 				Rule:         results.FieldPath("required"),
 				ConstraintId: proto.String("required"),
 			}),
+		},
+		"proto/2023/map/empty/ignore_always": suites.Case{
+			Message:  &cases.RequiredEditionsMapIgnoreAlways{},
+			Expected: results.Success(true),
 		},
 	}
 }


### PR DESCRIPTION
This adds 24 test cases to ensure that IGNORE_ALWAYS ignores the rule `required`, as in:

```proto
syntax = "proto3";
message Msg {
  string val = 1 [
    (buf.validate.field).required = true,
    (buf.validate.field).ignore = IGNORE_ALWAYS
  ];
}
```