### PR TITLE
Add more tests for isUri and isHostname

### DIFF
--- a/tools/protovalidate-conformance/internal/cases/cases_is_hostname.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_is_hostname.go
@@ -220,5 +220,13 @@ func isHostnameSuite() suites.Suite {
 				},
 			),
 		},
+		"invalid/fuzz1": {
+			Message: &cases.IsHostname{Val: "İ"},
+			Expected: results.Violations(
+				&validate.Violation{
+					ConstraintId: proto.String("library.is_hostname"),
+				},
+			),
+		},
 	}
 }

--- a/tools/protovalidate-conformance/internal/cases/cases_is_uri.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_is_uri.go
@@ -900,5 +900,9 @@ func isURISuite() suites.Suite {
 			Message:  &cases.IsUri{Val: "https://example.com/#0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-._~%20!$&'()*+,=;:@?/"},
 			Expected: results.Success(true),
 		},
+		"valid/fuzz1": {
+			Message:  &cases.IsUri{Val: "A://"},
+			Expected: results.Success(true),
+		},
 	}
 }


### PR DESCRIPTION
This adds test cases for https://github.com/bufbuild/protovalidate-go/pull/217 and https://github.com/bufbuild/protovalidate-go/pull/218.