### PR TITLE
Update create-release-draft action to need create-release-tag action to finish

### DIFF
--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -55,6 +55,7 @@ jobs:
 
   create-release-draft:
     name: Start release automation
+    needs: create-release-tag
     uses: ./.github/workflows/create-release-draft.yaml
     with:
       tag_name: ${{ github.event.inputs.tag_name }}


### PR DESCRIPTION
I think there is an ordering dependency here that we need to express. Not sure if this has caused any problems in practice, but if not we might have just been winning the race.