### PR TITLE
Add whitespace change for release bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ import "buf/validate/validate.proto";
 
 message MoneyTransfer {
   string to_account_id = 1 [
-    // Standard rule: `to_account_id` must be a UUID
+    // Standard rule: `to_account_id` must be a UUID.
     (buf.validate.field).string.uuid = true
   ];
 
   string from_account_id = 2 [
-    // Standard rule: `from_account_id` must be a UUID
+    // Standard rule: `from_account_id` must be a UUID.
     (buf.validate.field).string.uuid = true
   ];
 

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -184,7 +184,7 @@ message FieldRules {
   // described as "serialized in the wire format," which includes:
   //
   // - the following "nullable" fields must be explicitly set to be considered populated:
-  //   - singular message fields (whose fields may be unpopulated/default values)
+  //   - singular message fields (whose fields may be unpopulated / default values)
   //   - member fields of a oneof (may be their default value)
   //   - proto3 optional fields (may be their default value)
   //   - proto2 scalar fields (both optional and required)


### PR DESCRIPTION
This is a simple whitespace change to facilitate pushing out a new version of Protovalidate.