### PR TITLE
Clarify requried behavior for map keys/values and repeated items

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto3.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/required_field_proto3.proto
@@ -89,3 +89,15 @@ message RequiredProto3MapIgnoreAlways {
     (buf.validate.field).ignore = IGNORE_ALWAYS
   ];
 }
+
+message RequiredProto3MapKey {
+  map<string, string> val = 1 [(buf.validate.field).map.keys.required = true];
+}
+
+message RequiredProto3MapValue {
+  map<string, string> val = 1 [(buf.validate.field).map.values.required = true];
+}
+
+message RequiredProto3RepeatedItem {
+  repeated string val = 1 [(buf.validate.field).repeated.items.required = true];
+}

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -190,6 +190,7 @@ message FieldRules {
   //   - proto2 scalar fields (both optional and required)
   // - proto3 scalar fields must be non-zero to be considered populated
   // - repeated and map fields must be non-empty to be considered populated
+  // - map keys/values and repeated items are always considered populated
   //
   // ```proto
   // message MyMessage {

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4242,6 +4242,9 @@ message RepeatedRules {
   // in the field. Even for repeated message fields, validation is executed
   // against each item unless skip is explicitly specified.
   //
+  // Note that repeated items are always considered populated. The `required`
+  // rule does not apply.
+  //
   // ```proto
   // message MyRepeated {
   //   // The items in the field `value` must follow the specified rules.
@@ -4300,6 +4303,9 @@ message MapRules {
 
   //Specifies the rules to be applied to each key in the field.
   //
+  // Note that map keys are always considered populated. The `required`
+  // rule does not apply.
+  //
   // ```proto
   // message MyMap {
   //   // The keys in the field `value` must follow the specified rules.
@@ -4316,6 +4322,9 @@ message MapRules {
   //Specifies the rules to be applied to the value of each key in the
   // field. Message values will still have their validations evaluated unless
   //skip is specified here.
+  //
+  // Note that map values are always considered populated. The `required`
+  // rule does not apply.
   //
   // ```proto
   // message MyMap {

--- a/tools/internal/gen/buf/validate/conformance/cases/required_field_proto3.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/required_field_proto3.pb.go
@@ -640,6 +640,138 @@ func (x *RequiredProto3MapIgnoreAlways) GetVal() map[string]string {
 	return nil
 }
 
+type RequiredProto3MapKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           map[string]string      `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3MapKey) Reset() {
+	*x = RequiredProto3MapKey{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3MapKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3MapKey) ProtoMessage() {}
+
+func (x *RequiredProto3MapKey) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3MapKey.ProtoReflect.Descriptor instead.
+func (*RequiredProto3MapKey) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *RequiredProto3MapKey) GetVal() map[string]string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto3MapValue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           map[string]string      `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3MapValue) Reset() {
+	*x = RequiredProto3MapValue{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3MapValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3MapValue) ProtoMessage() {}
+
+func (x *RequiredProto3MapValue) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3MapValue.ProtoReflect.Descriptor instead.
+func (*RequiredProto3MapValue) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *RequiredProto3MapValue) GetVal() map[string]string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
+type RequiredProto3RepeatedItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Val           []string               `protobuf:"bytes,1,rep,name=val,proto3" json:"val,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RequiredProto3RepeatedItem) Reset() {
+	*x = RequiredProto3RepeatedItem{}
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RequiredProto3RepeatedItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RequiredProto3RepeatedItem) ProtoMessage() {}
+
+func (x *RequiredProto3RepeatedItem) ProtoReflect() protoreflect.Message {
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RequiredProto3RepeatedItem.ProtoReflect.Descriptor instead.
+func (*RequiredProto3RepeatedItem) Descriptor() ([]byte, []int) {
+	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RequiredProto3RepeatedItem) GetVal() []string {
+	if x != nil {
+		return x.Val
+	}
+	return nil
+}
+
 type RequiredProto3Message_Msg struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           string                 `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
@@ -649,7 +781,7 @@ type RequiredProto3Message_Msg struct {
 
 func (x *RequiredProto3Message_Msg) Reset() {
 	*x = RequiredProto3Message_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -661,7 +793,7 @@ func (x *RequiredProto3Message_Msg) String() string {
 func (*RequiredProto3Message_Msg) ProtoMessage() {}
 
 func (x *RequiredProto3Message_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -693,7 +825,7 @@ type RequiredProto3MessageIgnoreAlways_Msg struct {
 
 func (x *RequiredProto3MessageIgnoreAlways_Msg) Reset() {
 	*x = RequiredProto3MessageIgnoreAlways_Msg{}
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -705,7 +837,7 @@ func (x *RequiredProto3MessageIgnoreAlways_Msg) String() string {
 func (*RequiredProto3MessageIgnoreAlways_Msg) ProtoMessage() {}
 
 func (x *RequiredProto3MessageIgnoreAlways_Msg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -772,7 +904,19 @@ const file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc = 
 	"\x03val\x18\x01 \x03(\v2F.buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntryB\t\xbaH\x06\xc8\x01\x01\xd8\x01\x03R\x03val\x1a6\n" +
 	"\bValEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\xaf\x02\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xac\x01\n" +
+	"\x14RequiredProto3MapKey\x12\\\n" +
+	"\x03val\x18\x01 \x03(\v2=.buf.validate.conformance.cases.RequiredProto3MapKey.ValEntryB\v\xbaH\b\x9a\x01\x05\"\x03\xc8\x01\x01R\x03val\x1a6\n" +
+	"\bValEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb0\x01\n" +
+	"\x16RequiredProto3MapValue\x12^\n" +
+	"\x03val\x18\x01 \x03(\v2?.buf.validate.conformance.cases.RequiredProto3MapValue.ValEntryB\v\xbaH\b\x9a\x01\x05*\x03\xc8\x01\x01R\x03val\x1a6\n" +
+	"\bValEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\";\n" +
+	"\x1aRequiredProto3RepeatedItem\x12\x1d\n" +
+	"\x03val\x18\x01 \x03(\tB\v\xbaH\b\x92\x01\x05\"\x03\xc8\x01\x01R\x03valB\xaf\x02\n" +
 	"\"com.buf.validate.conformance.casesB\x18RequiredFieldProto3ProtoP\x01ZSgithub.com/bufbuild/protovalidate/tools/internal/gen/buf/validate/conformance/cases\xa2\x02\x04BVCC\xaa\x02\x1eBuf.Validate.Conformance.Cases\xca\x02\x1eBuf\\Validate\\Conformance\\Cases\xe2\x02*Buf\\Validate\\Conformance\\Cases\\GPBMetadata\xea\x02!Buf::Validate::Conformance::Casesb\x06proto3"
 
 var (
@@ -787,7 +931,7 @@ func file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescGZIP
 	return file_buf_validate_conformance_cases_required_field_proto3_proto_rawDescData
 }
 
-var file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_buf_validate_conformance_cases_required_field_proto3_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_buf_validate_conformance_cases_required_field_proto3_proto_goTypes = []any{
 	(*RequiredProto3Scalar)(nil),                     // 0: buf.validate.conformance.cases.RequiredProto3Scalar
 	(*RequiredProto3ScalarIgnoreAlways)(nil),         // 1: buf.validate.conformance.cases.RequiredProto3ScalarIgnoreAlways
@@ -801,21 +945,28 @@ var file_buf_validate_conformance_cases_required_field_proto3_proto_goTypes = []
 	(*RequiredProto3RepeatedIgnoreAlways)(nil),       // 9: buf.validate.conformance.cases.RequiredProto3RepeatedIgnoreAlways
 	(*RequiredProto3Map)(nil),                        // 10: buf.validate.conformance.cases.RequiredProto3Map
 	(*RequiredProto3MapIgnoreAlways)(nil),            // 11: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways
-	(*RequiredProto3Message_Msg)(nil),                // 12: buf.validate.conformance.cases.RequiredProto3Message.Msg
-	(*RequiredProto3MessageIgnoreAlways_Msg)(nil),    // 13: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
-	nil, // 14: buf.validate.conformance.cases.RequiredProto3Map.ValEntry
-	nil, // 15: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
+	(*RequiredProto3MapKey)(nil),                     // 12: buf.validate.conformance.cases.RequiredProto3MapKey
+	(*RequiredProto3MapValue)(nil),                   // 13: buf.validate.conformance.cases.RequiredProto3MapValue
+	(*RequiredProto3RepeatedItem)(nil),               // 14: buf.validate.conformance.cases.RequiredProto3RepeatedItem
+	(*RequiredProto3Message_Msg)(nil),                // 15: buf.validate.conformance.cases.RequiredProto3Message.Msg
+	(*RequiredProto3MessageIgnoreAlways_Msg)(nil),    // 16: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
+	nil, // 17: buf.validate.conformance.cases.RequiredProto3Map.ValEntry
+	nil, // 18: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
+	nil, // 19: buf.validate.conformance.cases.RequiredProto3MapKey.ValEntry
+	nil, // 20: buf.validate.conformance.cases.RequiredProto3MapValue.ValEntry
 }
 var file_buf_validate_conformance_cases_required_field_proto3_proto_depIdxs = []int32{
-	12, // 0: buf.validate.conformance.cases.RequiredProto3Message.val:type_name -> buf.validate.conformance.cases.RequiredProto3Message.Msg
-	13, // 1: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
-	14, // 2: buf.validate.conformance.cases.RequiredProto3Map.val:type_name -> buf.validate.conformance.cases.RequiredProto3Map.ValEntry
-	15, // 3: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
-	4,  // [4:4] is the sub-list for method output_type
-	4,  // [4:4] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	15, // 0: buf.validate.conformance.cases.RequiredProto3Message.val:type_name -> buf.validate.conformance.cases.RequiredProto3Message.Msg
+	16, // 1: buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MessageIgnoreAlways.Msg
+	17, // 2: buf.validate.conformance.cases.RequiredProto3Map.val:type_name -> buf.validate.conformance.cases.RequiredProto3Map.ValEntry
+	18, // 3: buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.val:type_name -> buf.validate.conformance.cases.RequiredProto3MapIgnoreAlways.ValEntry
+	19, // 4: buf.validate.conformance.cases.RequiredProto3MapKey.val:type_name -> buf.validate.conformance.cases.RequiredProto3MapKey.ValEntry
+	20, // 5: buf.validate.conformance.cases.RequiredProto3MapValue.val:type_name -> buf.validate.conformance.cases.RequiredProto3MapValue.ValEntry
+	6,  // [6:6] is the sub-list for method output_type
+	6,  // [6:6] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_buf_validate_conformance_cases_required_field_proto3_proto_init() }
@@ -839,7 +990,7 @@ func file_buf_validate_conformance_cases_required_field_proto3_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc), len(file_buf_validate_conformance_cases_required_field_proto3_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -5997,6 +5997,9 @@ type RepeatedRules struct {
 	// in the field. Even for repeated message fields, validation is executed
 	// against each item unless skip is explicitly specified.
 	//
+	// Note that repeated items are always considered populated. The `required`
+	// rule does not apply.
+	//
 	// ```proto
 	//
 	//	message MyRepeated {
@@ -6103,6 +6106,9 @@ type MapRules struct {
 	MaxPairs *uint64 `protobuf:"varint,2,opt,name=max_pairs,json=maxPairs" json:"max_pairs,omitempty"`
 	// Specifies the rules to be applied to each key in the field.
 	//
+	// Note that map keys are always considered populated. The `required`
+	// rule does not apply.
+	//
 	// ```proto
 	//
 	//	message MyMap {
@@ -6120,6 +6126,9 @@ type MapRules struct {
 	// Specifies the rules to be applied to the value of each key in the
 	// field. Message values will still have their validations evaluated unless
 	// skip is specified here.
+	//
+	// Note that map values are always considered populated. The `required`
+	// rule does not apply.
 	//
 	// ```proto
 	//

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -569,6 +569,7 @@ type FieldRules struct {
 	//
 	// - proto3 scalar fields must be non-zero to be considered populated
 	// - repeated and map fields must be non-empty to be considered populated
+	// - map keys/values and repeated items are always considered populated
 	//
 	// ```proto
 	//

--- a/tools/protovalidate-conformance/internal/cases/cases_required.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_required.go
@@ -280,6 +280,24 @@ func requiredSuite() suites.Suite {
 			Message:  &cases.RequiredProto3MapIgnoreAlways{},
 			Expected: results.Success(true),
 		},
+		"proto3/map/keys/required": suites.Case{
+			Message: &cases.RequiredProto3MapKey{
+				Val: map[string]string{"": "val"},
+			},
+			Expected: results.Success(true),
+		},
+		"proto3/map/values/required": suites.Case{
+			Message: &cases.RequiredProto3MapValue{
+				Val: map[string]string{"key": ""},
+			},
+			Expected: results.Success(true),
+		},
+		"proto3/repeated/items/required": suites.Case{
+			Message: &cases.RequiredProto3RepeatedItem{
+				Val: []string{""},
+			},
+			Expected: results.Success(true),
+		},
 		"proto/2023/scalar/explicit_presence/nonzero": suites.Case{
 			Message:  &cases.RequiredEditionsScalarExplicitPresence{Val: proto.String("foo")},
 			Expected: results.Success(true),


### PR DESCRIPTION
Internal report that there's some confusion about the behavior of when `FieldRules.map.keys.required`, `FieldRules.map.values.required`, and `FieldRules.repeated.items.required` are set to `true`. For maps, the KV pairs are explicitly set; while technically the key or value could be elided from the wire format to keep the size down, the field is always considered "set." Likewise, repeated items are always encoded, even if they are the zero value; it is impossible to have an unset repeated item (including messages).

This patch clarifies this in the `required` docs and adds a few conformance tests to enforce it. I kept it only to the proto3 required cases. I figured it would be overkill to take this further. Tested on protovalidate-go main (as of writing this).