### PR TITLE
Fix incorrect examples

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -847,7 +847,7 @@ message DoubleRules {
   // message MyDouble {
   //   double value = 1 [
   //     (buf.validate.field).double.example = 1.0,
-  //     (buf.validate.field).double.example = "Infinity"
+  //     (buf.validate.field).double.example = -2.0
   //   ];
   // }
   // ```

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -626,7 +626,7 @@ message FloatRules {
   // message MyFloat {
   //   float value = 1 [
   //     (buf.validate.field).float.example = 1.0,
-  //     (buf.validate.field).float.example = -2.0
+  //     (buf.validate.field).float.example = inf
   //   ];
   // }
   // ```
@@ -847,7 +847,7 @@ message DoubleRules {
   // message MyDouble {
   //   double value = 1 [
   //     (buf.validate.field).double.example = 1.0,
-  //     (buf.validate.field).double.example = -2.0
+  //     (buf.validate.field).double.example = inf
   //   ];
   // }
   // ```

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4374,7 +4374,7 @@ message AnyRules {
   // message MyAny {
   //   //  The `value` field must not have a `type_url` equal to any of the specified values.
   //   google.protobuf.Any value = 1 [(buf.validate.field).any = {
-  //       not_in: ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]
+  //       not_in: ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]
   //   }];
   // }
   // ```

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -626,7 +626,7 @@ message FloatRules {
   // message MyFloat {
   //   float value = 1 [
   //     (buf.validate.field).float.example = 1.0,
-  //     (buf.validate.field).float.example = "Infinity"
+  //     (buf.validate.field).float.example = -2.0
   //   ];
   // }
   // ```
@@ -4361,7 +4361,9 @@ message AnyRules {
   // ```proto
   // message MyAny {
   //   //  The `value` field must have a `type_url` equal to one of the specified values.
-  //   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
+  //   google.protobuf.Any value = 1 [(buf.validate.field).any = {
+  //       in: ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]
+  //   }];
   // }
   // ```
   repeated string in = 2;
@@ -4370,8 +4372,10 @@ message AnyRules {
   //
   // ```proto
   // message MyAny {
-  //   // The field `value` must not have a `type_url` equal to any of the specified values.
-  //   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
+  //   //  The `value` field must not have a `type_url` equal to any of the specified values.
+  //   google.protobuf.Any value = 1 [(buf.validate.field).any = {
+  //       not_in: ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]
+  //   }];
   // }
   // ```
   repeated string not_in = 3;

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -1130,7 +1130,7 @@ type FloatRules struct {
 	//	message MyFloat {
 	//	  float value = 1 [
 	//	    (buf.validate.field).float.example = 1.0,
-	//	    (buf.validate.field).float.example = -2.0
+	//	    (buf.validate.field).float.example = inf
 	//	  ];
 	//	}
 	//
@@ -1416,7 +1416,7 @@ type DoubleRules struct {
 	//	message MyDouble {
 	//	  double value = 1 [
 	//	    (buf.validate.field).double.example = 1.0,
-	//	    (buf.validate.field).double.example = -2.0
+	//	    (buf.validate.field).double.example = inf
 	//	  ];
 	//	}
 	//

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -1130,7 +1130,7 @@ type FloatRules struct {
 	//	message MyFloat {
 	//	  float value = 1 [
 	//	    (buf.validate.field).float.example = 1.0,
-	//	    (buf.validate.field).float.example = "Infinity"
+	//	    (buf.validate.field).float.example = -2.0
 	//	  ];
 	//	}
 	//
@@ -1416,7 +1416,7 @@ type DoubleRules struct {
 	//	message MyDouble {
 	//	  double value = 1 [
 	//	    (buf.validate.field).double.example = 1.0,
-	//	    (buf.validate.field).double.example = "Infinity"
+	//	    (buf.validate.field).double.example = -2.0
 	//	  ];
 	//	}
 	//
@@ -6218,7 +6218,9 @@ type AnyRules struct {
 	//
 	//	message MyAny {
 	//	  //  The `value` field must have a `type_url` equal to one of the specified values.
-	//	  google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
+	//	  google.protobuf.Any value = 1 [(buf.validate.field).any = {
+	//	      in: ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]
+	//	  }];
 	//	}
 	//
 	// ```
@@ -6228,8 +6230,10 @@ type AnyRules struct {
 	// ```proto
 	//
 	//	message MyAny {
-	//	  // The field `value` must not have a `type_url` equal to any of the specified values.
-	//	  google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
+	//	  //  The `value` field must not have a `type_url` equal to any of the specified values.
+	//	  google.protobuf.Any value = 1 [(buf.validate.field).any = {
+	//	      not_in: ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]
+	//	  }];
 	//	}
 	//
 	// ```


### PR DESCRIPTION
This fixes a few examples that don't compile as illustrated.

As a later follow-up, we should have an `examples.proto` test file that lists all these to verify they work.