### PR TITLE
Prep for v1.0.0-rc1 release

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -184,7 +184,7 @@ message FieldRules {
   // described as "serialized in the wire format," which includes:
   //
   // - the following "nullable" fields must be explicitly set to be considered populated:
-  //   - singular message fields (whose fields may be unpopulated / default values)
+  //   - singular message fields (whose fields may be unpopulated/default values)
   //   - member fields of a oneof (may be their default value)
   //   - proto3 optional fields (may be their default value)
   //   - proto2 scalar fields (both optional and required)

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -562,7 +562,7 @@ type FieldRules struct {
 	// described as "serialized in the wire format," which includes:
 	//
 	// - the following "nullable" fields must be explicitly set to be considered populated:
-	//   - singular message fields (whose fields may be unpopulated / default values)
+	//   - singular message fields (whose fields may be unpopulated/default values)
 	//   - member fields of a oneof (may be their default value)
 	//   - proto3 optional fields (may be their default value)
 	//   - proto2 scalar fields (both optional and required)


### PR DESCRIPTION
This is a simple whitespace change so that validate.proto will be synced to the BSR when we tag a `v1.0.0-rc1` release.