### PR TITLE
Update comments for Violation and Violations

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -276,7 +276,7 @@ message PredefinedRules {
 // Specifies how FieldRules.ignore behaves. See the documentation for
 // FieldRules.required for definitions of "populated" and "nullable".
 enum Ignore {
-  // Validation is only skipped if it's an unpopulated nullable fields.
+  // Validation is only skipped if it's an unpopulated nullable field.
   //
   // ```proto
   // syntax="proto3";
@@ -3809,7 +3809,7 @@ message StringRules {
   extensions 1000 to max;
 }
 
-// WellKnownRegex contain some well-known patterns.
+// KnownRegex contains some well-known patterns.
 enum KnownRegex {
   KNOWN_REGEX_UNSPECIFIED = 0;
 
@@ -4887,7 +4887,7 @@ message Violation {
   // ```
   optional FieldPath field = 5;
 
-  // `rule` is a machine-readable path that points to the specific rule rule that failed validation.
+  // `rule` is a machine-readable path that points to the specific rule that failed validation.
   // This will be a nested field starting from the FieldRules of the field that failed validation.
   // For custom rules, this will provide the path of the rule, e.g. `cel[0]`.
   //

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -43,7 +43,7 @@ const (
 type Ignore int32
 
 const (
-	// Validation is only skipped if it's an unpopulated nullable fields.
+	// Validation is only skipped if it's an unpopulated nullable field.
 	//
 	// ```proto
 	// syntax="proto3";
@@ -241,7 +241,7 @@ func (Ignore) EnumDescriptor() ([]byte, []int) {
 	return file_buf_validate_validate_proto_rawDescGZIP(), []int{0}
 }
 
-// WellKnownRegex contain some well-known patterns.
+// KnownRegex contains some well-known patterns.
 type KnownRegex int32
 
 const (
@@ -6982,7 +6982,7 @@ type Violation struct {
 	//
 	// ```
 	Field *FieldPath `protobuf:"bytes,5,opt,name=field" json:"field,omitempty"`
-	// `rule` is a machine-readable path that points to the specific rule rule that failed validation.
+	// `rule` is a machine-readable path that points to the specific rule that failed validation.
 	// This will be a nested field starting from the FieldRules of the field that failed validation.
 	// For custom rules, this will provide the path of the rule, e.g. `cel[0]`.
 	//


### PR DESCRIPTION
* Capitalizes "Protovalidate" in one comment used in generated docs
* Updates the JSON example for `Violation` to reflect its current fields. The example used isn't hand-typed: I just ran `toJsonString()` from `@bufbuild/protobuf` within the Protovalidate Playground on a `Violation`.