### PR TITLE
Clarify Protovalidate field presence

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -437,7 +437,7 @@ enum Ignore {
   // For fields that don't track presence, the field's value determines
   // whether the field is set and rules apply:
   //
-  // - For string and bytes bytes, and empty value is ignored.
+  // - For string and bytes, an empty value is ignored.
   // - For bool, false is ignored.
   // - For numeric types, zero is ignored.
   // - For enums, the first defined enum value is ignored.

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -187,9 +187,8 @@ message MessageOneofRule {
 // The `OneofRules` message type enables you to manage rules for
 // oneof fields in your protobuf messages.
 message OneofRules {
-  // If `required` is true, exactly one field of the oneof must be present. A
-  // validation error is returned if no fields in the oneof are present. The
-  // field itself may still be a default value; further rules
+  // If `required` is true, exactly one field of the oneof must be set. A
+  // validation error is returned if no fields in the oneof are set. Further rules
   // should be placed on the fields themselves to ensure they are valid values,
   // such as `min_len` or `gt`.
   //
@@ -225,27 +224,59 @@ message FieldRules {
   // }
   // ```
   repeated Rule cel = 23;
-  // If `required` is true, the field must be populated. A populated field can be
-  // described as "serialized in the wire format," which includes:
-  //
-  // - the following "nullable" fields must be explicitly set to be considered populated:
-  //   - singular message fields (whose fields may be unpopulated/default values)
-  //   - member fields of a oneof (may be their default value)
-  //   - proto3 optional fields (may be their default value)
-  //   - proto2 scalar fields (both optional and required)
-  // - proto3 scalar fields must be non-zero to be considered populated
-  // - repeated and map fields must be non-empty to be considered populated
-  // - map keys/values and repeated items are always considered populated
+  // If `required` is true, the field must be set. A validation error is returned
+  // if the field is not set.
   //
   // ```proto
-  // message MyMessage {
-  //   // The field `value` must be set to a non-null value.
-  //   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+  // syntax="proto3";
+  //
+  // message FieldsWithPresence {
+  //   // Requires any string to be set, including the empty string.
+  //   optional string link = 1 [
+  //     (buf.validate.field).required = true
+  //   ];
+  //   // Requires true or false to be set.
+  //   optional bool disabled = 2 [
+  //     (buf.validate.field).required = true
+  //   ];
+  //   // Requires a message to be set, including the empty message.
+  //   SomeMessage msg = 4 [
+  //     (buf.validate.field).required = true
+  //   ];
   // }
   // ```
+  //
+  // All fields in the example above track presence. By default, Protovalidate
+  // ignores rules on those fields if no value is set. `required` ensures that
+  // the fields are set and valid.
+  //
+  // Fields that don't track presence are always validated by Protovalidate,
+  // whether they are set or not. It is not necessary to add `required`:
+  //
+  // ```proto
+  // syntax="proto3";
+  //
+  // message FieldsWithoutPresence {
+  //   // `string.email` always applies, even to an empty string.
+  //   string link = 1 [
+  //     (buf.validate.field).string.email = true
+  //   ];
+  //   // `repeated.min_items` always applies, even to an empty list.
+  //   repeated string labels = 4 [
+  //     (buf.validate.field).repeated.min_items = 1
+  //   ];
+  // }
+  // ```
+  //
+  // To learn which fields track presence, see the
+  // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
+  //
+  // Note: While field rules can be applied to repeated items, map keys and map
+  // values, the elements are always considered to be set. Consequently,
+  // specifying `repeated.items.required` is redundant.
   optional bool required = 25;
-  // Skip validation on the field if its value matches the specified criteria.
-  // See Ignore enum for details.
+  // Ignore validation rules on the field if its value matches the specified
+  // criteria. See the `Ignore` enum for details.
   //
   // ```proto
   // message UpdateRequest {
@@ -253,7 +284,7 @@ message FieldRules {
   //   // string.
   //   optional string url = 1 [
   //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE,
-  //     (buf.validate.field).string.uri = true,
+  //     (buf.validate.field).string.uri = true
   //   ];
   // }
   // ```
@@ -318,140 +349,134 @@ message PredefinedRules {
 ;
 }
 
-// Specifies how FieldRules.ignore behaves. See the documentation for
-// FieldRules.required for definitions of "populated" and "nullable".
+// Specifies how `FieldRules.ignore` behaves, depending on the field's value, and
+// whether the field tracks presence.
 enum Ignore {
-  // Validation is only skipped if it's an unpopulated nullable field.
+  // Ignore rules if the field tracks presence and is unset. This is the default
+  // behavior.
+  //
+  // In proto3, only message fields, members of a Protobuf `oneof`, and fields
+  // with the `optional` label track presence. Consequently, the following fields
+  // are always validated, whether a value is set or not:
   //
   // ```proto
   // syntax="proto3";
   //
-  // message Request {
-  //   // The uri rule applies to any value, including the empty string.
-  //   string foo = 1 [
-  //     (buf.validate.field).string.uri = true
+  // message RulesApply {
+  //   string email = 1 [
+  //     (buf.validate.field).string.email = true
   //   ];
-  //
-  //   // The uri rule only applies if the field is set, including if it's
-  //   // set to the empty string.
-  //   optional string bar = 2 [
-  //     (buf.validate.field).string.uri = true
+  //   int32 age = 2 [
+  //     (buf.validate.field).int32.gt = 0
   //   ];
-  //
-  //   // The min_items rule always applies, even if the list is empty.
-  //   repeated string baz = 3 [
-  //     (buf.validate.field).repeated.min_items = 3
+  //   repeated string labels = 3 [
+  //     (buf.validate.field).repeated.min_items = 1
   //   ];
+  // }
+  // ```
   //
-  //   // The custom CEL rule applies only if the field is set, including if
-  //   // it's the "zero" value of that message.
-  //   SomeMessage quux = 4 [
+  // In contrast, the following fields track presence, and are only validated if
+  // a value is set:
+  //
+  // ```proto
+  // syntax="proto3";
+  //
+  // message RulesApplyIfSet {
+  //   optional string email = 1 [
+  //     (buf.validate.field).string.email = true
+  //   ];
+  //   oneof ref {
+  //     string reference = 2 [
+  //       (buf.validate.field).string.uuid = true
+  //     ];
+  //     string name = 3 [
+  //       (buf.validate.field).string.min_len = 4
+  //     ];
+  //   }
+  //   SomeMessage msg = 4 [
   //     (buf.validate.field).cel = {/* ... */}
   //   ];
   // }
   // ```
+  //
+  // To ensure that such a field is set, add the `required` rule.
+  //
+  // To learn which fields track presence, see the
+  // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
   IGNORE_UNSPECIFIED = 0;
 
-  // Validation is skipped if the field is unpopulated. This rule is redundant
-  // if the field is already nullable.
+  // Ignore rules if the field is unset, also for fields that don't track
+  // presence.
+  //
+  // In proto3, repeated fields, map fields, and fields with scalar types don't
+  // track presence. Consequently, the following fields are only validated if
+  // they are set:
   //
   // ```proto
-  // syntax="proto3
+  // syntax="proto3";
   //
-  // message Request {
-  //   // The uri rule applies only if the value is not the empty string.
-  //   string foo = 1 [
-  //     (buf.validate.field).string.uri = true,
+  // message RulesApplyIfSet {
+  //   // `string.email` is ignored for the empty string.
+  //   string link = 1 [
+  //     (buf.validate.field).string.email = true,
   //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
   //   ];
-  //
-  //   // IGNORE_IF_UNPOPULATED is equivalent to IGNORE_UNSPECIFIED in this
-  //   // case: the uri rule only applies if the field is set, including if
-  //   // it's set to the empty string.
-  //   optional string bar = 2 [
-  //     (buf.validate.field).string.uri = true,
+  //   // `int32.gte` is ignored for the zero value.
+  //   int32 age = 2 [
+  //     (buf.validate.field).int32.gte = 21,
   //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
   //   ];
-  //
-  //   // The min_items rule only applies if the list has at least one item.
-  //   repeated string baz = 3 [
+  //   // `repeated.min_items` is ignored if the list is empty.
+  //   repeated string labels = 3 [
   //     (buf.validate.field).repeated.min_items = 3,
-  //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-  //   ];
-  //
-  //   // IGNORE_IF_UNPOPULATED is equivalent to IGNORE_UNSPECIFIED in this
-  //   // case: the custom CEL rule applies only if the field is set, including
-  //   // if it's the "zero" value of that message.
-  //   SomeMessage quux = 4 [
-  //     (buf.validate.field).cel = {/* ... */},
   //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
   //   ];
   // }
   // ```
+  //
+  // For fields that don't track presence, the field's value determines
+  // whether the field is set and rules apply:
+  //
+  // - For string and bytes bytes, and empty value is ignored.
+  // - For bool, false is ignored.
+  // - For numeric types, zero is ignored.
+  // - For enums, the first defined enum value is ignored.
+  // - For repeated fields, an empty list is ignored.
+  // - For map fields, an empty map is ignored.
+  // - For message fields, absence of the message (typically a null-value) is
+  //   ignored.
+  //
+  // For fields that track presence (e.g. adding the `optional` label in proto3),
+  // behavior is the same as the default `IGNORE_UNSPECIFIED`.
+  //
+  // To learn which fields track presence, see the
+  // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
   IGNORE_IF_UNPOPULATED = 1;
 
-  // Validation is skipped if the field is unpopulated or if it is a nullable
-  // field populated with its default value. This is typically the zero or
-  // empty value, but proto2 scalars support custom defaults. For messages, the
-  // default is a non-null message with all its fields unpopulated.
+  // Ignore rules if the field is unset, or set to the default value.
   //
-  // ```proto
-  // syntax="proto3
+  // The default value depends on the field type:
+  // - For strings, the default value is the empty string.
+  // - For bytes, the default value is empty bytes.
+  // - For bool, the default value is false.
+  // - For numeric types, the default value is zero.
+  // - For enums, the default value is the first defined enum value.
+  // - For repeated fields, the default is an empty list.
+  // - For map fields, the default is an empty map.
+  // - For message fields, Protovalidate treats the empty message as the
+  //   default value. All rules of the referenced message are ignored as well.
   //
-  // message Request {
-  //   // IGNORE_IF_DEFAULT_VALUE is equivalent to IGNORE_IF_UNPOPULATED in
-  //   // this case; the uri rule applies only if the value is not the empty
-  //   // string.
-  //   string foo = 1 [
-  //     (buf.validate.field).string.uri = true,
-  //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-  //   ];
+  // For some fields, the default value can be overridden with the Protobuf
+  // `default` option.
   //
-  //   // The uri rule only applies if the field is set to a value other than
-  //   // the empty string.
-  //   optional string bar = 2 [
-  //     (buf.validate.field).string.uri = true,
-  //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-  //   ];
-  //
-  //   // IGNORE_IF_DEFAULT_VALUE is equivalent to IGNORE_IF_UNPOPULATED in
-  //   // this case; the min_items rule only applies if the list has at least
-  //   // one item.
-  //   repeated string baz = 3 [
-  //     (buf.validate.field).repeated.min_items = 3,
-  //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-  //   ];
-  //
-  //   // The custom CEL rule only applies if the field is set to a value other
-  //   // than an empty message (i.e., fields are unpopulated).
-  //   SomeMessage quux = 4 [
-  //     (buf.validate.field).cel = {/* ... */},
-  //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-  //   ];
-  // }
-  // ```
-  //
-  // This rule is affected by proto2 custom default values:
-  //
-  // ```proto
-  // syntax="proto2";
-  //
-  // message Request {
-  //   // The gt rule only applies if the field is set and it's value is not
-  //   the default (i.e., not -42). The rule even applies if the field is set
-  //   to zero since the default value differs.
-  //   optional int32 value = 1 [
-  //     default = -42,
-  //     (buf.validate.field).int32.gt = 0,
-  //     (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-  //   ];
-  // }
+  // For fields that don't track presence and don't have the `default` option,
+  // behavior is the same as the default `IGNORE_UNSPECIFIED`.
   IGNORE_IF_DEFAULT_VALUE = 2;
 
-  // The validation rules of this field will be skipped and not evaluated. This
-  // is useful for situations that necessitate turning off the rules of a field
-  // containing a message that may not make sense in the current context, or to
-  // temporarily disable rules during development.
+  // Always ignore rules, including the `required` rule.
+  //
+  // This is useful for ignoring the rules of a referenced message, or to
+  // temporarily ignore rules during development.
   //
   // ```proto
   // message MyMessage {
@@ -4285,10 +4310,7 @@ message RepeatedRules {
 
   // `items` details the rules to be applied to each item
   // in the field. Even for repeated message fields, validation is executed
-  // against each item unless skip is explicitly specified.
-  //
-  // Note that repeated items are always considered populated. The `required`
-  // rule does not apply.
+  // against each item unless `ignore` is specified.
   //
   // ```proto
   // message MyRepeated {
@@ -4301,6 +4323,9 @@ message RepeatedRules {
   //   }];
   // }
   // ```
+  //
+  // Note that the `required` rules does not apply. Repeated items
+  // cannot be unset.
   optional FieldRules items = 4;
 
   // Extension fields in this range that have the (buf.validate.predefined)
@@ -4318,7 +4343,7 @@ message RepeatedRules {
 
 // MapRules describe the rules applied to `map` values.
 message MapRules {
-  //Specifies the minimum number of key-value pairs allowed. If the field has
+  // Specifies the minimum number of key-value pairs allowed. If the field has
   // fewer key-value pairs than specified, an error message is generated.
   //
   // ```proto
@@ -4332,7 +4357,7 @@ message MapRules {
     expression: "uint(this.size()) < rules.min_pairs ? 'map must be at least %d entries'.format([rules.min_pairs]) : ''"
   }];
 
-  //Specifies the maximum number of key-value pairs allowed. If the field has
+  // Specifies the maximum number of key-value pairs allowed. If the field has
   // more key-value pairs than specified, an error message is generated.
   //
   // ```proto
@@ -4346,10 +4371,7 @@ message MapRules {
     expression: "uint(this.size()) > rules.max_pairs ? 'map must be at most %d entries'.format([rules.max_pairs]) : ''"
   }];
 
-  //Specifies the rules to be applied to each key in the field.
-  //
-  // Note that map keys are always considered populated. The `required`
-  // rule does not apply.
+  // Specifies the rules to be applied to each key in the field.
   //
   // ```proto
   // message MyMap {
@@ -4362,14 +4384,13 @@ message MapRules {
   //   }];
   // }
   // ```
+  //
+  // Note that the `required` rule does not apply. Map keys cannot be unset.
   optional FieldRules keys = 4;
 
-  //Specifies the rules to be applied to the value of each key in the
+  // Specifies the rules to be applied to the value of each key in the
   // field. Message values will still have their validations evaluated unless
-  //skip is specified here.
-  //
-  // Note that map values are always considered populated. The `required`
-  // rule does not apply.
+  // `ignore` is specified.
   //
   // ```proto
   // message MyMap {
@@ -4382,6 +4403,7 @@ message MapRules {
   //   }];
   // }
   // ```
+  // Note that the `required` rule does not apply. Map values cannot be unset.
   optional FieldRules values = 5;
 
   // Extension fields in this range that have the (buf.validate.predefined)

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4324,7 +4324,7 @@ message RepeatedRules {
   // }
   // ```
   //
-  // Note that the `required` rules does not apply. Repeated items
+  // Note that the `required` rule does not apply. Repeated items
   // cannot be unset.
   optional FieldRules items = 4;
 

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -271,7 +271,7 @@ message FieldRules {
   // To learn which fields track presence, see the
   // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
   //
-  // Note: While field rules can be applied to repeated items, map keys and map
+  // Note: While field rules can be applied to repeated items, map keys, and map
   // values, the elements are always considered to be set. Consequently,
   // specifying `repeated.items.required` is redundant.
   optional bool required = 25;

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -130,7 +130,7 @@ const (
 	// For fields that don't track presence, the field's value determines
 	// whether the field is set and rules apply:
 	//
-	//   - For string and bytes bytes, and empty value is ignored.
+	//   - For string and bytes, an empty value is ignored.
 	//   - For bool, false is ignored.
 	//   - For numeric types, zero is ignored.
 	//   - For enums, the first defined enum value is ignored.
@@ -6135,7 +6135,7 @@ type RepeatedRules struct {
 	//
 	// ```
 	//
-	// Note that the `required` rules does not apply. Repeated items
+	// Note that the `required` rule does not apply. Repeated items
 	// cannot be unset.
 	Items           *FieldRules `protobuf:"bytes,4,opt,name=items" json:"items,omitempty"`
 	extensionFields protoimpl.ExtensionFields

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -38,142 +38,136 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Specifies how FieldRules.ignore behaves. See the documentation for
-// FieldRules.required for definitions of "populated" and "nullable".
+// Specifies how `FieldRules.ignore` behaves, depending on the field's value, and
+// whether the field tracks presence.
 type Ignore int32
 
 const (
-	// Validation is only skipped if it's an unpopulated nullable field.
+	// Ignore rules if the field tracks presence and is unset. This is the default
+	// behavior.
+	//
+	// In proto3, only message fields, members of a Protobuf `oneof`, and fields
+	// with the `optional` label track presence. Consequently, the following fields
+	// are always validated, whether a value is set or not:
 	//
 	// ```proto
 	// syntax="proto3";
 	//
-	//	message Request {
-	//	  // The uri rule applies to any value, including the empty string.
-	//	  string foo = 1 [
-	//	    (buf.validate.field).string.uri = true
+	//	message RulesApply {
+	//	  string email = 1 [
+	//	    (buf.validate.field).string.email = true
 	//	  ];
-	//
-	//	  // The uri rule only applies if the field is set, including if it's
-	//	  // set to the empty string.
-	//	  optional string bar = 2 [
-	//	    (buf.validate.field).string.uri = true
+	//	  int32 age = 2 [
+	//	    (buf.validate.field).int32.gt = 0
 	//	  ];
-	//
-	//	  // The min_items rule always applies, even if the list is empty.
-	//	  repeated string baz = 3 [
-	//	    (buf.validate.field).repeated.min_items = 3
+	//	  repeated string labels = 3 [
+	//	    (buf.validate.field).repeated.min_items = 1
 	//	  ];
+	//	}
 	//
-	//	  // The custom CEL rule applies only if the field is set, including if
-	//	  // it's the "zero" value of that message.
-	//	  SomeMessage quux = 4 [
+	// ```
+	//
+	// In contrast, the following fields track presence, and are only validated if
+	// a value is set:
+	//
+	// ```proto
+	// syntax="proto3";
+	//
+	//	message RulesApplyIfSet {
+	//	  optional string email = 1 [
+	//	    (buf.validate.field).string.email = true
+	//	  ];
+	//	  oneof ref {
+	//	    string reference = 2 [
+	//	      (buf.validate.field).string.uuid = true
+	//	    ];
+	//	    string name = 3 [
+	//	      (buf.validate.field).string.min_len = 4
+	//	    ];
+	//	  }
+	//	  SomeMessage msg = 4 [
 	//	    (buf.validate.field).cel = {/* ... */}
 	//	  ];
 	//	}
 	//
 	// ```
+	//
+	// To ensure that such a field is set, add the `required` rule.
+	//
+	// To learn which fields track presence, see the
+	// [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
 	Ignore_IGNORE_UNSPECIFIED Ignore = 0
-	// Validation is skipped if the field is unpopulated. This rule is redundant
-	// if the field is already nullable.
+	// Ignore rules if the field is unset, also for fields that don't track
+	// presence.
+	//
+	// In proto3, repeated fields, map fields, and fields with scalar types don't
+	// track presence. Consequently, the following fields are only validated if
+	// they are set:
 	//
 	// ```proto
-	// syntax="proto3
+	// syntax="proto3";
 	//
-	//	message Request {
-	//	  // The uri rule applies only if the value is not the empty string.
-	//	  string foo = 1 [
-	//	    (buf.validate.field).string.uri = true,
+	//	message RulesApplyIfSet {
+	//	  // `string.email` is ignored for the empty string.
+	//	  string link = 1 [
+	//	    (buf.validate.field).string.email = true,
 	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
 	//	  ];
-	//
-	//	  // IGNORE_IF_UNPOPULATED is equivalent to IGNORE_UNSPECIFIED in this
-	//	  // case: the uri rule only applies if the field is set, including if
-	//	  // it's set to the empty string.
-	//	  optional string bar = 2 [
-	//	    (buf.validate.field).string.uri = true,
+	//	  // `int32.gte` is ignored for the zero value.
+	//	  int32 age = 2 [
+	//	    (buf.validate.field).int32.gte = 21,
 	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
 	//	  ];
-	//
-	//	  // The min_items rule only applies if the list has at least one item.
-	//	  repeated string baz = 3 [
+	//	  // `repeated.min_items` is ignored if the list is empty.
+	//	  repeated string labels = 3 [
 	//	    (buf.validate.field).repeated.min_items = 3,
-	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-	//	  ];
-	//
-	//	  // IGNORE_IF_UNPOPULATED is equivalent to IGNORE_UNSPECIFIED in this
-	//	  // case: the custom CEL rule applies only if the field is set, including
-	//	  // if it's the "zero" value of that message.
-	//	  SomeMessage quux = 4 [
-	//	    (buf.validate.field).cel = {/* ... */},
 	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
 	//	  ];
 	//	}
 	//
 	// ```
+	//
+	// For fields that don't track presence, the field's value determines
+	// whether the field is set and rules apply:
+	//
+	//   - For string and bytes bytes, and empty value is ignored.
+	//   - For bool, false is ignored.
+	//   - For numeric types, zero is ignored.
+	//   - For enums, the first defined enum value is ignored.
+	//   - For repeated fields, an empty list is ignored.
+	//   - For map fields, an empty map is ignored.
+	//   - For message fields, absence of the message (typically a null-value) is
+	//     ignored.
+	//
+	// For fields that track presence (e.g. adding the `optional` label in proto3),
+	// behavior is the same as the default `IGNORE_UNSPECIFIED`.
+	//
+	// To learn which fields track presence, see the
+	// [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
 	Ignore_IGNORE_IF_UNPOPULATED Ignore = 1
-	// Validation is skipped if the field is unpopulated or if it is a nullable
-	// field populated with its default value. This is typically the zero or
-	// empty value, but proto2 scalars support custom defaults. For messages, the
-	// default is a non-null message with all its fields unpopulated.
+	// Ignore rules if the field is unset, or set to the default value.
 	//
-	// ```proto
-	// syntax="proto3
+	// The default value depends on the field type:
+	//   - For strings, the default value is the empty string.
+	//   - For bytes, the default value is empty bytes.
+	//   - For bool, the default value is false.
+	//   - For numeric types, the default value is zero.
+	//   - For enums, the default value is the first defined enum value.
+	//   - For repeated fields, the default is an empty list.
+	//   - For map fields, the default is an empty map.
+	//   - For message fields, Protovalidate treats the empty message as the
+	//     default value. All rules of the referenced message are ignored as well.
 	//
-	//	message Request {
-	//	  // IGNORE_IF_DEFAULT_VALUE is equivalent to IGNORE_IF_UNPOPULATED in
-	//	  // this case; the uri rule applies only if the value is not the empty
-	//	  // string.
-	//	  string foo = 1 [
-	//	    (buf.validate.field).string.uri = true,
-	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-	//	  ];
+	// For some fields, the default value can be overridden with the Protobuf
+	// `default` option.
 	//
-	//	  // The uri rule only applies if the field is set to a value other than
-	//	  // the empty string.
-	//	  optional string bar = 2 [
-	//	    (buf.validate.field).string.uri = true,
-	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-	//	  ];
-	//
-	//	  // IGNORE_IF_DEFAULT_VALUE is equivalent to IGNORE_IF_UNPOPULATED in
-	//	  // this case; the min_items rule only applies if the list has at least
-	//	  // one item.
-	//	  repeated string baz = 3 [
-	//	    (buf.validate.field).repeated.min_items = 3,
-	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-	//	  ];
-	//
-	//	  // The custom CEL rule only applies if the field is set to a value other
-	//	  // than an empty message (i.e., fields are unpopulated).
-	//	  SomeMessage quux = 4 [
-	//	    (buf.validate.field).cel = {/* ... */},
-	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-	//	  ];
-	//	}
-	//
-	// ```
-	//
-	// This rule is affected by proto2 custom default values:
-	//
-	// ```proto
-	// syntax="proto2";
-	//
-	//	message Request {
-	//	  // The gt rule only applies if the field is set and it's value is not
-	//	  the default (i.e., not -42). The rule even applies if the field is set
-	//	  to zero since the default value differs.
-	//	  optional int32 value = 1 [
-	//	    default = -42,
-	//	    (buf.validate.field).int32.gt = 0,
-	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE
-	//	  ];
-	//	}
+	// For fields that don't track presence and don't have the `default` option,
+	// behavior is the same as the default `IGNORE_UNSPECIFIED`.
 	Ignore_IGNORE_IF_DEFAULT_VALUE Ignore = 2
-	// The validation rules of this field will be skipped and not evaluated. This
-	// is useful for situations that necessitate turning off the rules of a field
-	// containing a message that may not make sense in the current context, or to
-	// temporarily disable rules during development.
+	// Always ignore rules, including the `required` rule.
+	//
+	// This is useful for ignoring the rules of a referenced message, or to
+	// temporarily ignore rules during development.
 	//
 	// ```proto
 	//
@@ -576,9 +570,8 @@ func (x *MessageOneofRule) GetRequired() bool {
 // oneof fields in your protobuf messages.
 type OneofRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// If `required` is true, exactly one field of the oneof must be present. A
-	// validation error is returned if no fields in the oneof are present. The
-	// field itself may still be a default value; further rules
+	// If `required` is true, exactly one field of the oneof must be set. A
+	// validation error is returned if no fields in the oneof are set. Further rules
 	// should be placed on the fields themselves to ensure they are valid values,
 	// such as `min_len` or `gt`.
 	//
@@ -658,30 +651,61 @@ type FieldRules struct {
 	//
 	// ```
 	Cel []*Rule `protobuf:"bytes,23,rep,name=cel" json:"cel,omitempty"`
-	// If `required` is true, the field must be populated. A populated field can be
-	// described as "serialized in the wire format," which includes:
-	//
-	// - the following "nullable" fields must be explicitly set to be considered populated:
-	//   - singular message fields (whose fields may be unpopulated/default values)
-	//   - member fields of a oneof (may be their default value)
-	//   - proto3 optional fields (may be their default value)
-	//   - proto2 scalar fields (both optional and required)
-	//
-	// - proto3 scalar fields must be non-zero to be considered populated
-	// - repeated and map fields must be non-empty to be considered populated
-	// - map keys/values and repeated items are always considered populated
+	// If `required` is true, the field must be set. A validation error is returned
+	// if the field is not set.
 	//
 	// ```proto
+	// syntax="proto3";
 	//
-	//	message MyMessage {
-	//	  // The field `value` must be set to a non-null value.
-	//	  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+	//	message FieldsWithPresence {
+	//	  // Requires any string to be set, including the empty string.
+	//	  optional string link = 1 [
+	//	    (buf.validate.field).required = true
+	//	  ];
+	//	  // Requires true or false to be set.
+	//	  optional bool disabled = 2 [
+	//	    (buf.validate.field).required = true
+	//	  ];
+	//	  // Requires a message to be set, including the empty message.
+	//	  SomeMessage msg = 4 [
+	//	    (buf.validate.field).required = true
+	//	  ];
 	//	}
 	//
 	// ```
+	//
+	// All fields in the example above track presence. By default, Protovalidate
+	// ignores rules on those fields if no value is set. `required` ensures that
+	// the fields are set and valid.
+	//
+	// Fields that don't track presence are always validated by Protovalidate,
+	// whether they are set or not. It is not necessary to add `required`:
+	//
+	// ```proto
+	// syntax="proto3";
+	//
+	//	message FieldsWithoutPresence {
+	//	  // `string.email` always applies, even to an empty string.
+	//	  string link = 1 [
+	//	    (buf.validate.field).string.email = true
+	//	  ];
+	//	  // `repeated.min_items` always applies, even to an empty list.
+	//	  repeated string labels = 4 [
+	//	    (buf.validate.field).repeated.min_items = 1
+	//	  ];
+	//	}
+	//
+	// ```
+	//
+	// To learn which fields track presence, see the
+	// [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
+	//
+	// Note: While field rules can be applied to repeated items, map keys, and map
+	// values, the elements are always considered to be set. Consequently,
+	// specifying `repeated.items.required` is redundant.
 	Required *bool `protobuf:"varint,25,opt,name=required" json:"required,omitempty"`
-	// Skip validation on the field if its value matches the specified criteria.
-	// See Ignore enum for details.
+	// Ignore validation rules on the field if its value matches the specified
+	// criteria. See the `Ignore` enum for details.
 	//
 	// ```proto
 	//
@@ -690,7 +714,7 @@ type FieldRules struct {
 	//	  // string.
 	//	  optional string url = 1 [
 	//	    (buf.validate.field).ignore = IGNORE_IF_DEFAULT_VALUE,
-	//	    (buf.validate.field).string.uri = true,
+	//	    (buf.validate.field).string.uri = true
 	//	  ];
 	//	}
 	//
@@ -6095,10 +6119,7 @@ type RepeatedRules struct {
 	Unique *bool `protobuf:"varint,3,opt,name=unique" json:"unique,omitempty"`
 	// `items` details the rules to be applied to each item
 	// in the field. Even for repeated message fields, validation is executed
-	// against each item unless skip is explicitly specified.
-	//
-	// Note that repeated items are always considered populated. The `required`
-	// rule does not apply.
+	// against each item unless `ignore` is specified.
 	//
 	// ```proto
 	//
@@ -6113,6 +6134,9 @@ type RepeatedRules struct {
 	//	}
 	//
 	// ```
+	//
+	// Note that the `required` rules does not apply. Repeated items
+	// cannot be unset.
 	Items           *FieldRules `protobuf:"bytes,4,opt,name=items" json:"items,omitempty"`
 	extensionFields protoimpl.ExtensionFields
 	unknownFields   protoimpl.UnknownFields
@@ -6206,9 +6230,6 @@ type MapRules struct {
 	MaxPairs *uint64 `protobuf:"varint,2,opt,name=max_pairs,json=maxPairs" json:"max_pairs,omitempty"`
 	// Specifies the rules to be applied to each key in the field.
 	//
-	// Note that map keys are always considered populated. The `required`
-	// rule does not apply.
-	//
 	// ```proto
 	//
 	//	message MyMap {
@@ -6222,13 +6243,12 @@ type MapRules struct {
 	//	}
 	//
 	// ```
+	//
+	// Note that the `required` rule does not apply. Map keys cannot be unset.
 	Keys *FieldRules `protobuf:"bytes,4,opt,name=keys" json:"keys,omitempty"`
 	// Specifies the rules to be applied to the value of each key in the
 	// field. Message values will still have their validations evaluated unless
-	// skip is specified here.
-	//
-	// Note that map values are always considered populated. The `required`
-	// rule does not apply.
+	// `ignore` is specified.
 	//
 	// ```proto
 	//
@@ -6243,6 +6263,7 @@ type MapRules struct {
 	//	}
 	//
 	// ```
+	// Note that the `required` rule does not apply. Map values cannot be unset.
 	Values          *FieldRules `protobuf:"bytes,5,opt,name=values" json:"values,omitempty"`
 	extensionFields protoimpl.ExtensionFields
 	unknownFields   protoimpl.UnknownFields


### PR DESCRIPTION
For `FieldRules.required`:
- Give examples for cases where `required` is useful, and where it is redundant.
- Defer to the Protobuf documentation for a quick overview over field presence.

For `Ignore`:
- Explain the default behavior for implicit and explicit presence fields with examples.
- Explain how `FieldRules.required` fits in with `FieldRules.ignore`.
- Simplify the example to not include redundant definitions (e.g. `IGNORE_IF_UNPOPULATED` on explicit presence fields).
- List the exact ignored zero values / default values.

Update the terminology:
- Replace "nullability" with "tracks presence". It's the term coined by Editions. The Protobuf documentation [explains](https://protobuf.dev/design-decisions/nullable-getters-setters/) that explicit presence is different from nullability. I'm not sure whether the Protobuf documentation on field presence is ideal, but I believe that it helps users if we use the same terminology.
- Replace "populated" with "set" when referring to a field's presence. When using Protovalidate with Editions, users need to consult the Protobuf documentation to understand how validation applies, and the documentation on field presence does not mention "populated" once. 
- Replace "Skip" with "Ignore" in comments, following https://github.com/bufbuild/protovalidate/pull/172.

(This PR also includes a few unrelated whitespace fixes, and fixes several syntactical errors in the examples given in comments.)