### PR TITLE
Fix WORKSPACE bazel instructions in release message

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -63,7 +63,7 @@ http_archive(
     sha256 = "${SHA256}",
     strip_prefix = "${PREFIX}",
     urls = [
-        "https://github.com/bufbuild/protovalidate/releases/download/${TAG}/protovalidate-${TAG}.tar.gz",
+        "https://github.com/bufbuild/protovalidate/releases/download/${TAG}/protovalidate-${TAG:1}.tar.gz",
     ],
 )
 \`\`\`


### PR DESCRIPTION
For example, https://github.com/bufbuild/protovalidate/releases/tag/v1.0.0-rc.4 says to use
https://github.com/bufbuild/protovalidate/releases/download/v1.0.0-rc.4/protovalidate-v1.0.0-rc.4.tar.gz which 404s. But
https://github.com/bufbuild/protovalidate/releases/download/v1.0.0-rc.4/protovalidate-1.0.0-rc.4.tar.gz is a valid link.

Of course I may be missing something, but as resolving the former link fails both in my browser and in Bazel, I believe the issue is in the script.