### PR TITLE
feat: add bic to stringrules

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/strings.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/strings.proto
@@ -203,6 +203,10 @@ message StringHttpHeaderValue {
   string val = 1 [(buf.validate.field).string.well_known_regex = KNOWN_REGEX_HTTP_HEADER_VALUE];
 }
 
+message StringBic {
+  string val = 1 [(buf.validate.field).string.bic = true];
+}
+
 message StringHttpHeaderNameLoose {
   string val = 1 [(buf.validate.field).string = {
     well_known_regex: KNOWN_REGEX_HTTP_HEADER_NAME

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -3833,6 +3833,32 @@ message StringRules {
           "'^[^\\u0000\\u000A\\u000D]*$')"
       }
     ];
+
+    // `bic` specifies that the field value must be a valid BIC (Bank Identifier Code),
+    // also known as SWIFT code.
+    // example, "FXBBGB22".
+    //
+    // If the field value is not a valid Bic, an error message will be
+    // generated.
+    //
+    // ```proto
+    // message MyString {
+    //   // value must be a valid Bic
+    //    string value = 1 [(buf.validate.field).string.bic = true];
+    // }
+    // ```
+    bool bic = 35 [
+    (predefined).cel = {
+      id: "string.bic"
+      message: "value must be a valid BIC"
+      expression: "!rules.bic || this.matches('^([A-Z]{6}[A-Z0-9]{2}[A-Z0-9]{0,3})$'" 
+    },
+    (predefined).cel = {
+      id: "string.bic_empty"
+      message: "value is empty, which is not a valid BIC"
+      expression: "!rules.bic || this != ''"
+    }
+  ];
   }
 
   // This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to


### PR DESCRIPTION
Hello, I am trying to add a bic rule to the stringrules. My goal is to be able to validate that a string match the BIC format as defined by the [ISO_9362](https://en.wikipedia.org/wiki/ISO_9362). 

I think I added the rule in the right place but I don't understand how I should change the tests. If you have the time, it would be kind of you to give me some pointers.

Thanks for this amazing project, I am looking forward to your response !