### PR TITLE
[DO NOT MERGE]: Update links to buf.build/docs to use protovalidate.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To start using Protovalidate in your projects, see the [developer quickstart][qu
 
 ## Documentation
 
-Comprehensive documentation for Protovalidate is available in [Buf's documentation library][protovalidate].
+Comprehensive documentation for Protovalidate at [protovalidate.com][protovalidate].
 
 Highlights include:
 
@@ -81,10 +81,10 @@ Offered under the [Apache 2 license][license].
 [conformance]: https://github.com/bufbuild/protovalidate/blob/main/docs/conformance.md
 [ci]: https://github.com/bufbuild/protovalidate/actions/workflows/ci.yaml
 
-[protovalidate]: https://buf.build/docs/protovalidate/
-[quickstart]: https://buf.build/docs/protovalidate/quickstart/
-[connect-go]: https://buf.build/docs/protovalidate/quickstart/connect-go/
-[grpc-go]: https://buf.build/docs/protovalidate/quickstart/grpc-go/
-[grpc-java]: https://buf.build/docs/protovalidate/quickstart/grpc-java/
-[grpc-python]: https://buf.build/docs/protovalidate/quickstart/grpc-python/
+[protovalidate]: .https://protovalidate.com/
+[quickstart]: .https://protovalidate.com/quickstart/
+[connect-go]: .https://protovalidate.com/quickstart/connect-go/
+[grpc-go]: .https://protovalidate.com/quickstart/grpc-go/
+[grpc-java]: .https://protovalidate.com/quickstart/grpc-java/
+[grpc-python]: .https://protovalidate.com/quickstart/grpc-python/
 [migration-guide]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Offered under the [Apache 2 license][license].
 [conformance]: https://github.com/bufbuild/protovalidate/blob/main/docs/conformance.md
 [ci]: https://github.com/bufbuild/protovalidate/actions/workflows/ci.yaml
 
-[protovalidate]: .https://protovalidate.com/
-[quickstart]: .https://protovalidate.com/quickstart/
-[connect-go]: .https://protovalidate.com/quickstart/connect-go/
-[grpc-go]: .https://protovalidate.com/quickstart/grpc-go/
-[grpc-java]: .https://protovalidate.com/quickstart/grpc-java/
-[grpc-python]: .https://protovalidate.com/quickstart/grpc-python/
+[protovalidate]: https://protovalidate.com/
+[quickstart]: https://protovalidate.com/quickstart/
+[connect-go]: https://protovalidate.com/quickstart/connect-go/
+[grpc-go]: https://protovalidate.com/quickstart/grpc-go/
+[grpc-java]: https://protovalidate.com/quickstart/grpc-java/
+[grpc-python]: https://protovalidate.com/quickstart/grpc-python/
 [migration-guide]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Offered under the [Apache 2 license][license].
 [grpc-go]: https://protovalidate.com/quickstart/grpc-go/
 [grpc-java]: https://protovalidate.com/quickstart/grpc-java/
 [grpc-python]: https://protovalidate.com/quickstart/grpc-python/
-[migration-guide]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/
+[migration-guide]: https://protovalidate.com/migration-guides/migrate-from-protoc-gen-validate/

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 # Documentation
 
-This page has moved to [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[violation-reference]: https://buf.build/docs/reference/protovalidate/violations/
+[protovalidate]: .https://protovalidate.com/
+[violation-reference]: .https://protovalidate.com/reference/violations/

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,5 @@
 This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[violation-reference]: .https://protovalidate.com/reference/violations/
+[protovalidate]: https://protovalidate.com/
+[violation-reference]: https://protovalidate.com/reference/violations/

--- a/docs/cel.md
+++ b/docs/cel.md
@@ -6,7 +6,7 @@
 
 ## Learn more about CEL in Protovalidate
 
-Learn more about using CEL in [Protovalidate's documentation][protovalidate]:
+Learn more about using CEL at [protovalidate.com][protovalidate]:
 
 - Write [custom rules][custom-rules] for messages or fields.
 - Create reusable [predefined rules][predefined-rules].
@@ -21,10 +21,10 @@ Protovalidate CEL expressions can use the entire CEL standard library, including
 - CEL's standard [macros](https://github.com/google/cel-spec/blob/v0.8.0/doc/langdef.md#macros)
 - CEL's [extended string function library](https://pkg.go.dev/github.com/google/cel-go/ext#Strings)
 
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/
 [cel]: https://cel.dev
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
-[predefined-rules]: https://buf.build/docs/protovalidate/schemas/predefined-rules/
-[cel-extensions]: https://buf.build/docs/reference/protovalidate/cel_extensions/
-[advanced-cel]: https://buf.build/docs/protovalidate/cel/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
+[cel-extensions]: .https://protovalidate.com/reference/cel_extensions/
+[advanced-cel]: .https://protovalidate.com/cel/

--- a/docs/cel.md
+++ b/docs/cel.md
@@ -21,10 +21,10 @@ Protovalidate CEL expressions can use the entire CEL standard library, including
 - CEL's standard [macros](https://github.com/google/cel-spec/blob/v0.8.0/doc/langdef.md#macros)
 - CEL's [extended string function library](https://pkg.go.dev/github.com/google/cel-go/ext#Strings)
 
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/
 [cel]: https://cel.dev
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
-[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
-[cel-extensions]: .https://protovalidate.com/reference/cel_extensions/
-[advanced-cel]: .https://protovalidate.com/cel/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/
+[predefined-rules]: https://protovalidate.com/schemas/predefined-rules/
+[cel-extensions]: https://protovalidate.com/reference/cel_extensions/
+[advanced-cel]: https://protovalidate.com/cel/

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -2,8 +2,8 @@
 
 # Custom rules
 
-This page has moved to [custom rules][custom-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [custom rules][custom-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
+[protovalidate]: .https://protovalidate.com/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -5,5 +5,5 @@
 This page has moved to [custom rules][custom-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[protovalidate]: https://protovalidate.com/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -5,5 +5,5 @@
 This page has moved to the [violation reference][violation-reference] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[violation-reference]: .https://protovalidate.com/reference/violations/
+[protovalidate]: https://protovalidate.com/
+[violation-reference]: https://protovalidate.com/reference/violations/

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -2,8 +2,8 @@
 
 # Rule violations
 
-This page has moved to the [violation reference][violation-reference] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to the [violation reference][violation-reference] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[violation-reference]: https://buf.build/docs/reference/protovalidate/violations/
+[protovalidate]: .https://protovalidate.com/
+[violation-reference]: .https://protovalidate.com/reference/violations/

--- a/docs/predefined-rules.md
+++ b/docs/predefined-rules.md
@@ -2,8 +2,8 @@
 
 # Predefined rules
 
-This page has been moved to [predefined rules][predefined-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has been moved to [predefined rules][predefined-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[predefined-rules]: https://buf.build/docs/protovalidate/schemas/predefined-rules/
+[protovalidate]: .https://protovalidate.com/
+[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/

--- a/docs/predefined-rules.md
+++ b/docs/predefined-rules.md
@@ -5,5 +5,5 @@
 This page has been moved to [predefined rules][predefined-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
+[protovalidate]: https://protovalidate.com/
+[predefined-rules]: https://protovalidate.com/schemas/predefined-rules/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,7 +2,7 @@
 
 # Rules
 
-This page has moved to [Protovalidate's comprehensive documentation][protovalidate] at [Buf][buf].
+This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -5,4 +5,4 @@
 This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/

--- a/docs/standard-rules.md
+++ b/docs/standard-rules.md
@@ -5,5 +5,5 @@
 This page has moved to [standard rules][standard-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[protovalidate]: https://protovalidate.com/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/

--- a/docs/standard-rules.md
+++ b/docs/standard-rules.md
@@ -2,8 +2,8 @@
 
 # Standard rules
 
-This page has moved to [standard rules][standard-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [standard rules][standard-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
+[protovalidate]: .https://protovalidate.com/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,10 @@ The following direct links can be used to find the examples that used to be in t
 - Discover how CEL-based [custom rules][custom-rules] allow you to express business rules within Protobuf.
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/
 [protovalidate-examples]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate
 [standard-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-standard
 [custom-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-custom
-[quickstart]: https://buf.build/docs/protovalidate/quickstart/
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
+[quickstart]: .https://protovalidate.com/quickstart/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,10 @@ The following direct links can be used to find the examples that used to be in t
 - Discover how CEL-based [custom rules][custom-rules] allow you to express business rules within Protobuf.
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/
 [protovalidate-examples]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate
 [standard-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-standard
 [custom-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-custom
-[quickstart]: .https://protovalidate.com/quickstart/
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[quickstart]: https://protovalidate.com/quickstart/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -76,7 +76,7 @@ extend google.protobuf.FieldOptions {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+// information, [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 // message Foo {
@@ -122,7 +122,7 @@ message MessageRules {
 
   // `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
   // These rules are written in Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
   //
   //
   // ```proto
@@ -211,7 +211,7 @@ message OneofRules {
 message FieldRules {
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
   //
   // ```proto
   // message MyMessage {
@@ -328,7 +328,7 @@ message FieldRules {
 message PredefinedRules {
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/predefined-rules/).
+  // [see our documentation](.https://protovalidate.com/schemas/predefined-rules/).
   //
   // ```proto
   // message MyMessage {

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -76,7 +76,7 @@ extend google.protobuf.FieldOptions {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+// information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 // message Foo {
@@ -122,7 +122,7 @@ message MessageRules {
 
   // `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
   // These rules are written in Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   //
   // ```proto
@@ -211,7 +211,7 @@ message OneofRules {
 message FieldRules {
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   // ```proto
   // message MyMessage {
@@ -328,7 +328,7 @@ message FieldRules {
 message PredefinedRules {
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](.https://protovalidate.com/schemas/predefined-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/predefined-rules/).
   //
   // ```proto
   // message MyMessage {

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -300,7 +300,7 @@ func (KnownRegex) EnumDescriptor() ([]byte, []int) {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+// information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 //
@@ -402,7 +402,7 @@ type MessageRules struct {
 	Disabled *bool `protobuf:"varint,1,opt,name=disabled" json:"disabled,omitempty"`
 	// `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
 	// These rules are written in Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -636,7 +636,7 @@ type FieldRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -1134,7 +1134,7 @@ type PredefinedRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](.https://protovalidate.com/schemas/predefined-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/predefined-rules/).
 	//
 	// ```proto
 	//

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -300,7 +300,7 @@ func (KnownRegex) EnumDescriptor() ([]byte, []int) {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+// information, [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 //
@@ -402,7 +402,7 @@ type MessageRules struct {
 	Disabled *bool `protobuf:"varint,1,opt,name=disabled" json:"disabled,omitempty"`
 	// `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
 	// These rules are written in Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -636,7 +636,7 @@ type FieldRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// [see our documentation](.https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -1134,7 +1134,7 @@ type PredefinedRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/predefined-rules/).
+	// [see our documentation](.https://protovalidate.com/schemas/predefined-rules/).
 	//
 	// ```proto
 	//

--- a/tools/protovalidate-migrate/README.md
+++ b/tools/protovalidate-migrate/README.md
@@ -6,5 +6,5 @@ Migrating from `protoc-gen-validate` to `protovalidate` should be safe, incremen
 
 Visit [Buf's documentation][migrate] to learn about automated and manual migrations.
 
-[migrate]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/
+[migrate]: https://protovalidate.com/migration-guides/migrate-from-protoc-gen-validate/
 


### PR DESCRIPTION
**Cannot be merged until protovalidate.com is live _and_ we've reviewed/verified every change for validity.**

* Updates all links to buf.build/docs to use protovalidate.com.
* Updates grammar/wording in READMEs to better suit this change.