### PR TITLE
Remove (buf.validate.message).disabled

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/messages.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/messages.proto
@@ -29,11 +29,6 @@ message MessageNone {
   message NoneMsg {}
 }
 
-message MessageDisabled {
-  option (buf.validate.message).disabled = true;
-  uint64 val = 1 [(buf.validate.field).uint64.gt = 123];
-}
-
 message Message {
   TestMsg val = 1;
 }

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -164,7 +164,7 @@ message MessageRules {
   repeated MessageOneofRule oneof = 4;
 
   reserved 1;
-  reserved "deleted";
+  reserved "disabled";
 }
 
 message MessageOneofRule {

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -109,17 +109,6 @@ message Rule {
 // MessageRules represents validation rules that are applied to the entire message.
 // It includes disabling options and a list of Rule messages representing Common Expression Language (CEL) validation rules.
 message MessageRules {
-  // `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
-  // This includes any fields within the message that would otherwise support validation.
-  //
-  // ```proto
-  // message MyMessage {
-  //   // validation will be bypassed for this message
-  //   option (buf.validate.message).disabled = true;
-  // }
-  // ```
-  optional bool disabled = 1;
-
   // `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
   // These rules are written in Common Expression Language (CEL) syntax. For more information,
   // [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
@@ -173,6 +162,9 @@ message MessageRules {
   // }
   // ```
   repeated MessageOneofRule oneof = 4;
+
+  reserved 1;
+  reserved "deleted";
 }
 
 message MessageOneofRule {

--- a/tools/internal/gen/buf/validate/conformance/cases/messages.pb.go
+++ b/tools/internal/gen/buf/validate/conformance/cases/messages.pb.go
@@ -133,50 +133,6 @@ func (x *MessageNone) GetVal() *MessageNone_NoneMsg {
 	return nil
 }
 
-type MessageDisabled struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Val           uint64                 `protobuf:"varint,1,opt,name=val,proto3" json:"val,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *MessageDisabled) Reset() {
-	*x = MessageDisabled{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *MessageDisabled) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*MessageDisabled) ProtoMessage() {}
-
-func (x *MessageDisabled) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use MessageDisabled.ProtoReflect.Descriptor instead.
-func (*MessageDisabled) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *MessageDisabled) GetVal() uint64 {
-	if x != nil {
-		return x.Val
-	}
-	return 0
-}
-
 type Message struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Val           *TestMsg               `protobuf:"bytes,1,opt,name=val,proto3" json:"val,omitempty"`
@@ -186,7 +142,7 @@ type Message struct {
 
 func (x *Message) Reset() {
 	*x = Message{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -198,7 +154,7 @@ func (x *Message) String() string {
 func (*Message) ProtoMessage() {}
 
 func (x *Message) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[3]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -211,7 +167,7 @@ func (x *Message) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Message.ProtoReflect.Descriptor instead.
 func (*Message) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{3}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Message) GetVal() *TestMsg {
@@ -230,7 +186,7 @@ type MessageCrossPackage struct {
 
 func (x *MessageCrossPackage) Reset() {
 	*x = MessageCrossPackage{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -242,7 +198,7 @@ func (x *MessageCrossPackage) String() string {
 func (*MessageCrossPackage) ProtoMessage() {}
 
 func (x *MessageCrossPackage) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[4]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -255,7 +211,7 @@ func (x *MessageCrossPackage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageCrossPackage.ProtoReflect.Descriptor instead.
 func (*MessageCrossPackage) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{4}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *MessageCrossPackage) GetVal() *other_package.Embed {
@@ -274,7 +230,7 @@ type MessageSkip struct {
 
 func (x *MessageSkip) Reset() {
 	*x = MessageSkip{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -286,7 +242,7 @@ func (x *MessageSkip) String() string {
 func (*MessageSkip) ProtoMessage() {}
 
 func (x *MessageSkip) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[5]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -299,7 +255,7 @@ func (x *MessageSkip) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageSkip.ProtoReflect.Descriptor instead.
 func (*MessageSkip) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{5}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *MessageSkip) GetVal() *TestMsg {
@@ -318,7 +274,7 @@ type MessageRequired struct {
 
 func (x *MessageRequired) Reset() {
 	*x = MessageRequired{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -330,7 +286,7 @@ func (x *MessageRequired) String() string {
 func (*MessageRequired) ProtoMessage() {}
 
 func (x *MessageRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[6]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -343,7 +299,7 @@ func (x *MessageRequired) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRequired.ProtoReflect.Descriptor instead.
 func (*MessageRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{6}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *MessageRequired) GetVal() *TestMsg {
@@ -362,7 +318,7 @@ type MessageRequiredButOptional struct {
 
 func (x *MessageRequiredButOptional) Reset() {
 	*x = MessageRequiredButOptional{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -374,7 +330,7 @@ func (x *MessageRequiredButOptional) String() string {
 func (*MessageRequiredButOptional) ProtoMessage() {}
 
 func (x *MessageRequiredButOptional) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[7]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -387,7 +343,7 @@ func (x *MessageRequiredButOptional) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRequiredButOptional.ProtoReflect.Descriptor instead.
 func (*MessageRequiredButOptional) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{7}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *MessageRequiredButOptional) GetVal() *TestMsg {
@@ -409,7 +365,7 @@ type MessageRequiredOneof struct {
 
 func (x *MessageRequiredOneof) Reset() {
 	*x = MessageRequiredOneof{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[8]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -421,7 +377,7 @@ func (x *MessageRequiredOneof) String() string {
 func (*MessageRequiredOneof) ProtoMessage() {}
 
 func (x *MessageRequiredOneof) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[8]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,7 +390,7 @@ func (x *MessageRequiredOneof) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageRequiredOneof.ProtoReflect.Descriptor instead.
 func (*MessageRequiredOneof) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{8}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *MessageRequiredOneof) GetOne() isMessageRequiredOneof_One {
@@ -471,7 +427,7 @@ type MessageWith3DInside struct {
 
 func (x *MessageWith3DInside) Reset() {
 	*x = MessageWith3DInside{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[9]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -483,7 +439,7 @@ func (x *MessageWith3DInside) String() string {
 func (*MessageWith3DInside) ProtoMessage() {}
 
 func (x *MessageWith3DInside) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[9]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -496,7 +452,7 @@ func (x *MessageWith3DInside) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageWith3DInside.ProtoReflect.Descriptor instead.
 func (*MessageWith3DInside) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{9}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{8}
 }
 
 type MessageOneofSingleField struct {
@@ -509,7 +465,7 @@ type MessageOneofSingleField struct {
 
 func (x *MessageOneofSingleField) Reset() {
 	*x = MessageOneofSingleField{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[10]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -521,7 +477,7 @@ func (x *MessageOneofSingleField) String() string {
 func (*MessageOneofSingleField) ProtoMessage() {}
 
 func (x *MessageOneofSingleField) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[10]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -534,7 +490,7 @@ func (x *MessageOneofSingleField) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofSingleField.ProtoReflect.Descriptor instead.
 func (*MessageOneofSingleField) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{10}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *MessageOneofSingleField) GetStrField() string {
@@ -561,7 +517,7 @@ type MessageOneofSingleFieldRequired struct {
 
 func (x *MessageOneofSingleFieldRequired) Reset() {
 	*x = MessageOneofSingleFieldRequired{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[11]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -573,7 +529,7 @@ func (x *MessageOneofSingleFieldRequired) String() string {
 func (*MessageOneofSingleFieldRequired) ProtoMessage() {}
 
 func (x *MessageOneofSingleFieldRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[11]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -586,7 +542,7 @@ func (x *MessageOneofSingleFieldRequired) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofSingleFieldRequired.ProtoReflect.Descriptor instead.
 func (*MessageOneofSingleFieldRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{11}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *MessageOneofSingleFieldRequired) GetStrField() string {
@@ -613,7 +569,7 @@ type MessageOneofMultipleFields struct {
 
 func (x *MessageOneofMultipleFields) Reset() {
 	*x = MessageOneofMultipleFields{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -625,7 +581,7 @@ func (x *MessageOneofMultipleFields) String() string {
 func (*MessageOneofMultipleFields) ProtoMessage() {}
 
 func (x *MessageOneofMultipleFields) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[12]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -638,7 +594,7 @@ func (x *MessageOneofMultipleFields) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofMultipleFields.ProtoReflect.Descriptor instead.
 func (*MessageOneofMultipleFields) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{12}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *MessageOneofMultipleFields) GetStrField() string {
@@ -665,7 +621,7 @@ type MessageOneofMultipleFieldsRequired struct {
 
 func (x *MessageOneofMultipleFieldsRequired) Reset() {
 	*x = MessageOneofMultipleFieldsRequired{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -677,7 +633,7 @@ func (x *MessageOneofMultipleFieldsRequired) String() string {
 func (*MessageOneofMultipleFieldsRequired) ProtoMessage() {}
 
 func (x *MessageOneofMultipleFieldsRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[13]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -690,7 +646,7 @@ func (x *MessageOneofMultipleFieldsRequired) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use MessageOneofMultipleFieldsRequired.ProtoReflect.Descriptor instead.
 func (*MessageOneofMultipleFieldsRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{13}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *MessageOneofMultipleFieldsRequired) GetStrField() string {
@@ -718,7 +674,7 @@ type MessageOneofMultipleSharedFields struct {
 
 func (x *MessageOneofMultipleSharedFields) Reset() {
 	*x = MessageOneofMultipleSharedFields{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[14]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -730,7 +686,7 @@ func (x *MessageOneofMultipleSharedFields) String() string {
 func (*MessageOneofMultipleSharedFields) ProtoMessage() {}
 
 func (x *MessageOneofMultipleSharedFields) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[14]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -743,7 +699,7 @@ func (x *MessageOneofMultipleSharedFields) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofMultipleSharedFields.ProtoReflect.Descriptor instead.
 func (*MessageOneofMultipleSharedFields) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{14}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *MessageOneofMultipleSharedFields) GetStrField() string {
@@ -776,7 +732,7 @@ type MessageOneofUnknownFieldName struct {
 
 func (x *MessageOneofUnknownFieldName) Reset() {
 	*x = MessageOneofUnknownFieldName{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[15]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -788,7 +744,7 @@ func (x *MessageOneofUnknownFieldName) String() string {
 func (*MessageOneofUnknownFieldName) ProtoMessage() {}
 
 func (x *MessageOneofUnknownFieldName) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[15]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -801,7 +757,7 @@ func (x *MessageOneofUnknownFieldName) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofUnknownFieldName.ProtoReflect.Descriptor instead.
 func (*MessageOneofUnknownFieldName) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{15}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *MessageOneofUnknownFieldName) GetStrField() string {
@@ -821,7 +777,7 @@ type MessageOneofDuplicateField struct {
 
 func (x *MessageOneofDuplicateField) Reset() {
 	*x = MessageOneofDuplicateField{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[16]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -833,7 +789,7 @@ func (x *MessageOneofDuplicateField) String() string {
 func (*MessageOneofDuplicateField) ProtoMessage() {}
 
 func (x *MessageOneofDuplicateField) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[16]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -846,7 +802,7 @@ func (x *MessageOneofDuplicateField) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofDuplicateField.ProtoReflect.Descriptor instead.
 func (*MessageOneofDuplicateField) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{16}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *MessageOneofDuplicateField) GetStrField() string {
@@ -873,7 +829,7 @@ type MessageOneofZeroFields struct {
 
 func (x *MessageOneofZeroFields) Reset() {
 	*x = MessageOneofZeroFields{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[17]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -885,7 +841,7 @@ func (x *MessageOneofZeroFields) String() string {
 func (*MessageOneofZeroFields) ProtoMessage() {}
 
 func (x *MessageOneofZeroFields) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[17]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -898,7 +854,7 @@ func (x *MessageOneofZeroFields) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofZeroFields.ProtoReflect.Descriptor instead.
 func (*MessageOneofZeroFields) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{17}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *MessageOneofZeroFields) GetStrField() string {
@@ -926,7 +882,7 @@ type MessageOneofUnsatisfiable struct {
 
 func (x *MessageOneofUnsatisfiable) Reset() {
 	*x = MessageOneofUnsatisfiable{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[18]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -938,7 +894,7 @@ func (x *MessageOneofUnsatisfiable) String() string {
 func (*MessageOneofUnsatisfiable) ProtoMessage() {}
 
 func (x *MessageOneofUnsatisfiable) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[18]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -951,7 +907,7 @@ func (x *MessageOneofUnsatisfiable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofUnsatisfiable.ProtoReflect.Descriptor instead.
 func (*MessageOneofUnsatisfiable) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{18}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *MessageOneofUnsatisfiable) GetA() bool {
@@ -985,7 +941,7 @@ type MessageOneofIgnoreUnpopulated struct {
 
 func (x *MessageOneofIgnoreUnpopulated) Reset() {
 	*x = MessageOneofIgnoreUnpopulated{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[19]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -997,7 +953,7 @@ func (x *MessageOneofIgnoreUnpopulated) String() string {
 func (*MessageOneofIgnoreUnpopulated) ProtoMessage() {}
 
 func (x *MessageOneofIgnoreUnpopulated) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[19]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1010,7 +966,7 @@ func (x *MessageOneofIgnoreUnpopulated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofIgnoreUnpopulated.ProtoReflect.Descriptor instead.
 func (*MessageOneofIgnoreUnpopulated) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{19}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *MessageOneofIgnoreUnpopulated) GetStrField() string {
@@ -1037,7 +993,7 @@ type MessageOneofIgnoreUnpopulatedRequired struct {
 
 func (x *MessageOneofIgnoreUnpopulatedRequired) Reset() {
 	*x = MessageOneofIgnoreUnpopulatedRequired{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[20]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1049,7 +1005,7 @@ func (x *MessageOneofIgnoreUnpopulatedRequired) String() string {
 func (*MessageOneofIgnoreUnpopulatedRequired) ProtoMessage() {}
 
 func (x *MessageOneofIgnoreUnpopulatedRequired) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[20]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1062,7 +1018,7 @@ func (x *MessageOneofIgnoreUnpopulatedRequired) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use MessageOneofIgnoreUnpopulatedRequired.ProtoReflect.Descriptor instead.
 func (*MessageOneofIgnoreUnpopulatedRequired) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{20}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *MessageOneofIgnoreUnpopulatedRequired) GetStrField() string {
@@ -1089,7 +1045,7 @@ type MessageOneofIgnoreOverride struct {
 
 func (x *MessageOneofIgnoreOverride) Reset() {
 	*x = MessageOneofIgnoreOverride{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[21]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1101,7 +1057,7 @@ func (x *MessageOneofIgnoreOverride) String() string {
 func (*MessageOneofIgnoreOverride) ProtoMessage() {}
 
 func (x *MessageOneofIgnoreOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[21]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1114,7 +1070,7 @@ func (x *MessageOneofIgnoreOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MessageOneofIgnoreOverride.ProtoReflect.Descriptor instead.
 func (*MessageOneofIgnoreOverride) Descriptor() ([]byte, []int) {
-	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{21}
+	return file_buf_validate_conformance_cases_messages_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *MessageOneofIgnoreOverride) GetMsgField() *TestMsg {
@@ -1139,7 +1095,7 @@ type MessageNone_NoneMsg struct {
 
 func (x *MessageNone_NoneMsg) Reset() {
 	*x = MessageNone_NoneMsg{}
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[22]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1151,7 +1107,7 @@ func (x *MessageNone_NoneMsg) String() string {
 func (*MessageNone_NoneMsg) ProtoMessage() {}
 
 func (x *MessageNone_NoneMsg) ProtoReflect() protoreflect.Message {
-	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[22]
+	mi := &file_buf_validate_conformance_cases_messages_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1179,9 +1135,7 @@ const file_buf_validate_conformance_cases_messages_proto_rawDesc = "" +
 	"\x06nested\x18\x02 \x01(\v2'.buf.validate.conformance.cases.TestMsgR\x06nested\"_\n" +
 	"\vMessageNone\x12E\n" +
 	"\x03val\x18\x01 \x01(\v23.buf.validate.conformance.cases.MessageNone.NoneMsgR\x03val\x1a\t\n" +
-	"\aNoneMsg\"3\n" +
-	"\x0fMessageDisabled\x12\x19\n" +
-	"\x03val\x18\x01 \x01(\x04B\a\xbaH\x042\x02 {R\x03val:\x05\xbaH\x02\b\x01\"D\n" +
+	"\aNoneMsg\"D\n" +
 	"\aMessage\x129\n" +
 	"\x03val\x18\x01 \x01(\v2'.buf.validate.conformance.cases.TestMsgR\x03val\"\\\n" +
 	"\x13MessageCrossPackage\x12E\n" +
@@ -1292,38 +1246,37 @@ func file_buf_validate_conformance_cases_messages_proto_rawDescGZIP() []byte {
 	return file_buf_validate_conformance_cases_messages_proto_rawDescData
 }
 
-var file_buf_validate_conformance_cases_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_buf_validate_conformance_cases_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_buf_validate_conformance_cases_messages_proto_goTypes = []any{
 	(*TestMsg)(nil),                               // 0: buf.validate.conformance.cases.TestMsg
 	(*MessageNone)(nil),                           // 1: buf.validate.conformance.cases.MessageNone
-	(*MessageDisabled)(nil),                       // 2: buf.validate.conformance.cases.MessageDisabled
-	(*Message)(nil),                               // 3: buf.validate.conformance.cases.Message
-	(*MessageCrossPackage)(nil),                   // 4: buf.validate.conformance.cases.MessageCrossPackage
-	(*MessageSkip)(nil),                           // 5: buf.validate.conformance.cases.MessageSkip
-	(*MessageRequired)(nil),                       // 6: buf.validate.conformance.cases.MessageRequired
-	(*MessageRequiredButOptional)(nil),            // 7: buf.validate.conformance.cases.MessageRequiredButOptional
-	(*MessageRequiredOneof)(nil),                  // 8: buf.validate.conformance.cases.MessageRequiredOneof
-	(*MessageWith3DInside)(nil),                   // 9: buf.validate.conformance.cases.MessageWith3dInside
-	(*MessageOneofSingleField)(nil),               // 10: buf.validate.conformance.cases.MessageOneofSingleField
-	(*MessageOneofSingleFieldRequired)(nil),       // 11: buf.validate.conformance.cases.MessageOneofSingleFieldRequired
-	(*MessageOneofMultipleFields)(nil),            // 12: buf.validate.conformance.cases.MessageOneofMultipleFields
-	(*MessageOneofMultipleFieldsRequired)(nil),    // 13: buf.validate.conformance.cases.MessageOneofMultipleFieldsRequired
-	(*MessageOneofMultipleSharedFields)(nil),      // 14: buf.validate.conformance.cases.MessageOneofMultipleSharedFields
-	(*MessageOneofUnknownFieldName)(nil),          // 15: buf.validate.conformance.cases.MessageOneofUnknownFieldName
-	(*MessageOneofDuplicateField)(nil),            // 16: buf.validate.conformance.cases.MessageOneofDuplicateField
-	(*MessageOneofZeroFields)(nil),                // 17: buf.validate.conformance.cases.MessageOneofZeroFields
-	(*MessageOneofUnsatisfiable)(nil),             // 18: buf.validate.conformance.cases.MessageOneofUnsatisfiable
-	(*MessageOneofIgnoreUnpopulated)(nil),         // 19: buf.validate.conformance.cases.MessageOneofIgnoreUnpopulated
-	(*MessageOneofIgnoreUnpopulatedRequired)(nil), // 20: buf.validate.conformance.cases.MessageOneofIgnoreUnpopulatedRequired
-	(*MessageOneofIgnoreOverride)(nil),            // 21: buf.validate.conformance.cases.MessageOneofIgnoreOverride
-	(*MessageNone_NoneMsg)(nil),                   // 22: buf.validate.conformance.cases.MessageNone.NoneMsg
-	(*other_package.Embed)(nil),                   // 23: buf.validate.conformance.cases.other_package.Embed
+	(*Message)(nil),                               // 2: buf.validate.conformance.cases.Message
+	(*MessageCrossPackage)(nil),                   // 3: buf.validate.conformance.cases.MessageCrossPackage
+	(*MessageSkip)(nil),                           // 4: buf.validate.conformance.cases.MessageSkip
+	(*MessageRequired)(nil),                       // 5: buf.validate.conformance.cases.MessageRequired
+	(*MessageRequiredButOptional)(nil),            // 6: buf.validate.conformance.cases.MessageRequiredButOptional
+	(*MessageRequiredOneof)(nil),                  // 7: buf.validate.conformance.cases.MessageRequiredOneof
+	(*MessageWith3DInside)(nil),                   // 8: buf.validate.conformance.cases.MessageWith3dInside
+	(*MessageOneofSingleField)(nil),               // 9: buf.validate.conformance.cases.MessageOneofSingleField
+	(*MessageOneofSingleFieldRequired)(nil),       // 10: buf.validate.conformance.cases.MessageOneofSingleFieldRequired
+	(*MessageOneofMultipleFields)(nil),            // 11: buf.validate.conformance.cases.MessageOneofMultipleFields
+	(*MessageOneofMultipleFieldsRequired)(nil),    // 12: buf.validate.conformance.cases.MessageOneofMultipleFieldsRequired
+	(*MessageOneofMultipleSharedFields)(nil),      // 13: buf.validate.conformance.cases.MessageOneofMultipleSharedFields
+	(*MessageOneofUnknownFieldName)(nil),          // 14: buf.validate.conformance.cases.MessageOneofUnknownFieldName
+	(*MessageOneofDuplicateField)(nil),            // 15: buf.validate.conformance.cases.MessageOneofDuplicateField
+	(*MessageOneofZeroFields)(nil),                // 16: buf.validate.conformance.cases.MessageOneofZeroFields
+	(*MessageOneofUnsatisfiable)(nil),             // 17: buf.validate.conformance.cases.MessageOneofUnsatisfiable
+	(*MessageOneofIgnoreUnpopulated)(nil),         // 18: buf.validate.conformance.cases.MessageOneofIgnoreUnpopulated
+	(*MessageOneofIgnoreUnpopulatedRequired)(nil), // 19: buf.validate.conformance.cases.MessageOneofIgnoreUnpopulatedRequired
+	(*MessageOneofIgnoreOverride)(nil),            // 20: buf.validate.conformance.cases.MessageOneofIgnoreOverride
+	(*MessageNone_NoneMsg)(nil),                   // 21: buf.validate.conformance.cases.MessageNone.NoneMsg
+	(*other_package.Embed)(nil),                   // 22: buf.validate.conformance.cases.other_package.Embed
 }
 var file_buf_validate_conformance_cases_messages_proto_depIdxs = []int32{
 	0,  // 0: buf.validate.conformance.cases.TestMsg.nested:type_name -> buf.validate.conformance.cases.TestMsg
-	22, // 1: buf.validate.conformance.cases.MessageNone.val:type_name -> buf.validate.conformance.cases.MessageNone.NoneMsg
+	21, // 1: buf.validate.conformance.cases.MessageNone.val:type_name -> buf.validate.conformance.cases.MessageNone.NoneMsg
 	0,  // 2: buf.validate.conformance.cases.Message.val:type_name -> buf.validate.conformance.cases.TestMsg
-	23, // 3: buf.validate.conformance.cases.MessageCrossPackage.val:type_name -> buf.validate.conformance.cases.other_package.Embed
+	22, // 3: buf.validate.conformance.cases.MessageCrossPackage.val:type_name -> buf.validate.conformance.cases.other_package.Embed
 	0,  // 4: buf.validate.conformance.cases.MessageSkip.val:type_name -> buf.validate.conformance.cases.TestMsg
 	0,  // 5: buf.validate.conformance.cases.MessageRequired.val:type_name -> buf.validate.conformance.cases.TestMsg
 	0,  // 6: buf.validate.conformance.cases.MessageRequiredButOptional.val:type_name -> buf.validate.conformance.cases.TestMsg
@@ -1341,8 +1294,8 @@ func file_buf_validate_conformance_cases_messages_proto_init() {
 	if File_buf_validate_conformance_cases_messages_proto != nil {
 		return
 	}
-	file_buf_validate_conformance_cases_messages_proto_msgTypes[7].OneofWrappers = []any{}
-	file_buf_validate_conformance_cases_messages_proto_msgTypes[8].OneofWrappers = []any{
+	file_buf_validate_conformance_cases_messages_proto_msgTypes[6].OneofWrappers = []any{}
+	file_buf_validate_conformance_cases_messages_proto_msgTypes[7].OneofWrappers = []any{
 		(*MessageRequiredOneof_Val)(nil),
 	}
 	type x struct{}
@@ -1351,7 +1304,7 @@ func file_buf_validate_conformance_cases_messages_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_buf_validate_conformance_cases_messages_proto_rawDesc), len(file_buf_validate_conformance_cases_messages_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   23,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -7539,10 +7539,10 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x03 \x01(\tR\n" +
-	"expression\"y\n" +
+	"expression\"z\n" +
 	"\fMessageRules\x12$\n" +
 	"\x03cel\x18\x03 \x03(\v2\x12.buf.validate.RuleR\x03cel\x124\n" +
-	"\x05oneof\x18\x04 \x03(\v2\x1e.buf.validate.MessageOneofRuleR\x05oneofJ\x04\b\x01\x10\x02R\adeleted\"F\n" +
+	"\x05oneof\x18\x04 \x03(\v2\x1e.buf.validate.MessageOneofRuleR\x05oneofJ\x04\b\x01\x10\x02R\bdisabled\"F\n" +
 	"\x10MessageOneofRule\x12\x16\n" +
 	"\x06fields\x18\x01 \x03(\tR\x06fields\x12\x1a\n" +
 	"\brequired\x18\x02 \x01(\bR\brequired\"(\n" +

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -388,18 +388,6 @@ func (x *Rule) GetExpression() string {
 // It includes disabling options and a list of Rule messages representing Common Expression Language (CEL) validation rules.
 type MessageRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
-	// This includes any fields within the message that would otherwise support validation.
-	//
-	// ```proto
-	//
-	//	message MyMessage {
-	//	  // validation will be bypassed for this message
-	//	  option (buf.validate.message).disabled = true;
-	//	}
-	//
-	// ```
-	Disabled *bool `protobuf:"varint,1,opt,name=disabled" json:"disabled,omitempty"`
 	// `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
 	// These rules are written in Common Expression Language (CEL) syntax. For more information,
 	// [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
@@ -487,13 +475,6 @@ func (x *MessageRules) ProtoReflect() protoreflect.Message {
 // Deprecated: Use MessageRules.ProtoReflect.Descriptor instead.
 func (*MessageRules) Descriptor() ([]byte, []int) {
 	return file_buf_validate_validate_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *MessageRules) GetDisabled() bool {
-	if x != nil && x.Disabled != nil {
-		return *x.Disabled
-	}
-	return false
 }
 
 func (x *MessageRules) GetCel() []*Rule {
@@ -7558,11 +7539,10 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1e\n" +
 	"\n" +
 	"expression\x18\x03 \x01(\tR\n" +
-	"expression\"\x86\x01\n" +
-	"\fMessageRules\x12\x1a\n" +
-	"\bdisabled\x18\x01 \x01(\bR\bdisabled\x12$\n" +
+	"expression\"y\n" +
+	"\fMessageRules\x12$\n" +
 	"\x03cel\x18\x03 \x03(\v2\x12.buf.validate.RuleR\x03cel\x124\n" +
-	"\x05oneof\x18\x04 \x03(\v2\x1e.buf.validate.MessageOneofRuleR\x05oneof\"F\n" +
+	"\x05oneof\x18\x04 \x03(\v2\x1e.buf.validate.MessageOneofRuleR\x05oneofJ\x04\b\x01\x10\x02R\adeleted\"F\n" +
 	"\x10MessageOneofRule\x12\x16\n" +
 	"\x06fields\x18\x01 \x03(\tR\x06fields\x12\x1a\n" +
 	"\brequired\x18\x02 \x01(\bR\brequired\"(\n" +

--- a/tools/protovalidate-conformance/internal/cases/cases_message.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_message.go
@@ -33,14 +33,6 @@ func messageSuite() suites.Suite {
 			Message:  &cases.MessageNone{},
 			Expected: results.Success(true),
 		},
-		"disabled/valid": {
-			Message:  &cases.MessageDisabled{Val: 456},
-			Expected: results.Success(true),
-		},
-		"disabled/invalid-field/valid": {
-			Message:  &cases.MessageDisabled{Val: 0},
-			Expected: results.Success(true),
-		},
 		"field/valid": {
 			Message:  &cases.Message{Val: &cases.TestMsg{Const: "foo"}},
 			Expected: results.Success(true),


### PR DESCRIPTION
The message option `(buf.validate.message).disabled` disables any validation rules for a message. 

We're removing the option to ensure that Protovalidate rules are easy to understand for authors and consumers. This is a breaking change.

To update your rules to this change, simply remove field rules and any custom message rules along with `(buf.validate.message).disabled`:

```diff
message Example {
-   option (buf.validate.message).disabled = true;
-   option (buf.validate.message).cel = {
-       id: "example"
-       message: "example"
-       expression: "false"
-   };
-   string email = 1 [(buf.validate.field).string.email = true];
}
```

If any field references a message with rules, set `IGNORE_ALWAYS` to disable the nested rules:

```diff
message Example {
-   option (buf.validate.message).disabled = true;
-   Foo foo = 1;
+   Foo foo = 1 [(buf.validate.field).string.ignore = IGNORE_ALWAYS];
}

message Foo {
   string email = 1 [(buf.validate.field).string.email = true];
}
```