### PR TITLE
Rename `IGNORE_IF_UNPOPULATED` to `IGNORE_IF_ZERO_VALUE`

### DIFF
--- a/proto/protovalidate-testing/buf/validate/conformance/cases/bytes.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/bytes.proto
@@ -94,7 +94,7 @@ message BytesNotIPv6 {
 message BytesIPv6Ignore {
   bytes val = 1 [
     (buf.validate.field).bytes.ipv6 = true,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 message BytesExample {

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto2.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto2.proto
@@ -20,14 +20,14 @@ import "buf/validate/validate.proto";
 
 message IgnoreEmptyProto2ScalarOptional {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message IgnoreEmptyProto2ScalarOptionalWithDefault {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = 42
   ];
@@ -35,14 +35,14 @@ message IgnoreEmptyProto2ScalarOptionalWithDefault {
 
 message IgnoreEmptyProto2ScalarRequired {
   required int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message IgnoreEmptyProto2Message {
   optional Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.proto2.message"
       message: "foobar"
@@ -57,7 +57,7 @@ message IgnoreEmptyProto2Message {
 message IgnoreEmptyProto2Oneof {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -65,14 +65,14 @@ message IgnoreEmptyProto2Oneof {
 
 message IgnoreEmptyProto2Repeated {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
 
 message IgnoreEmptyProto2Map {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto3.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto3.proto
@@ -20,21 +20,21 @@ import "buf/validate/validate.proto";
 
 message IgnoreEmptyProto3Scalar {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message IgnoreEmptyProto3OptionalScalar {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message IgnoreEmptyProto3Message {
   optional Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.proto3.message"
       message: "foobar"
@@ -49,7 +49,7 @@ message IgnoreEmptyProto3Message {
 message IgnoreEmptyProto3Oneof {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -57,21 +57,21 @@ message IgnoreEmptyProto3Oneof {
 
 message IgnoreEmptyProto3Repeated {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
 
 message IgnoreEmptyProto3Map {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }
 
 message IgnoreEmptyRepeatedItems {
   repeated int32 val = 1 [(buf.validate.field).repeated.items = {
-    ignore: IGNORE_IF_UNPOPULATED
+    ignore: IGNORE_IF_ZERO_VALUE
     int32: {gt: 0}
   }];
 }
@@ -79,11 +79,11 @@ message IgnoreEmptyRepeatedItems {
 message IgnoreEmptyMapPairs {
   map<string, int32> val = 1 [
     (buf.validate.field).map.keys = {
-      ignore: IGNORE_IF_UNPOPULATED
+      ignore: IGNORE_IF_ZERO_VALUE
       string: {min_len: 3}
     },
     (buf.validate.field).map.values = {
-      ignore: IGNORE_IF_UNPOPULATED
+      ignore: IGNORE_IF_ZERO_VALUE
       int32: {gt: 0}
     }
   ];

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto_editions.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_empty_proto_editions.proto
@@ -20,14 +20,14 @@ import "buf/validate/validate.proto";
 
 message IgnoreEmptyEditionsScalarExplicitPresence {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message IgnoreEmptyEditionsScalarExplicitPresenceWithDefault {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = 42
   ];
@@ -36,7 +36,7 @@ message IgnoreEmptyEditionsScalarExplicitPresenceWithDefault {
 message IgnoreEmptyEditionsScalarImplicitPresence {
   int32 val = 1 [
     features.field_presence = IMPLICIT,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -44,7 +44,7 @@ message IgnoreEmptyEditionsScalarImplicitPresence {
 message IgnoreEmptyEditionsScalarLegacyRequired {
   int32 val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -52,7 +52,7 @@ message IgnoreEmptyEditionsScalarLegacyRequired {
 message IgnoreEmptyEditionsScalarLegacyRequiredWithDefault {
   int32 val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = 42
   ];
@@ -60,7 +60,7 @@ message IgnoreEmptyEditionsScalarLegacyRequiredWithDefault {
 
 message IgnoreEmptyEditionsMessageExplicitPresence {
   Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.editions.message"
       message: "foobar"
@@ -75,7 +75,7 @@ message IgnoreEmptyEditionsMessageExplicitPresence {
 message IgnoreEmptyEditionsMessageExplicitPresenceDelimited {
   Msg val = 1 [
     features.message_encoding = DELIMITED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.editions.message"
       message: "foobar"
@@ -90,7 +90,7 @@ message IgnoreEmptyEditionsMessageExplicitPresenceDelimited {
 message IgnoreEmptyEditionsMessageLegacyRequired {
   Msg val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.editions.message"
       message: "foobar"
@@ -106,7 +106,7 @@ message IgnoreEmptyEditionsMessageLegacyRequiredDelimited {
   Msg val = 1 [
     features.message_encoding = DELIMITED,
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "ignore_empty.editions.message"
       message: "foobar"
@@ -121,7 +121,7 @@ message IgnoreEmptyEditionsMessageLegacyRequiredDelimited {
 message IgnoreEmptyEditionsOneof {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -129,7 +129,7 @@ message IgnoreEmptyEditionsOneof {
 
 message IgnoreEmptyEditionsRepeated {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
@@ -137,14 +137,14 @@ message IgnoreEmptyEditionsRepeated {
 message IgnoreEmptyEditionsRepeatedExpanded {
   repeated int32 val = 1 [
     features.repeated_field_encoding = EXPANDED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
 
 message IgnoreEmptyEditionsMap {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto2.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto2.proto
@@ -31,14 +31,14 @@ message Proto2ScalarOptionalIgnoreUnspecifiedWithDefault {
 
 message Proto2ScalarOptionalIgnoreEmpty {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message Proto2ScalarOptionalIgnoreEmptyWithDefault {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = -42
   ];
@@ -72,14 +72,14 @@ message Proto2ScalarRequiredIgnoreUnspecifiedWithDefault {
 
 message Proto2ScalarRequiredIgnoreEmpty {
   required int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message Proto2ScalarRequiredIgnoreEmptyWithDefault {
   required int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = -42
   ];
@@ -113,7 +113,7 @@ message Proto2MessageOptionalIgnoreUnspecified {
 
 message Proto2MessageOptionalIgnoreEmpty {
   optional Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto2.message.ignore.empty"
       message: "foobar"
@@ -152,7 +152,7 @@ message Proto2MessageRequiredIgnoreUnspecified {
 
 message Proto2MessageRequiredIgnoreEmpty {
   required Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto2.message.ignore.empty"
       message: "foobar"
@@ -196,7 +196,7 @@ message Proto2OneofIgnoreUnspecifiedWithDefault {
 message Proto2OneofIgnoreEmpty {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -205,7 +205,7 @@ message Proto2OneofIgnoreEmpty {
 message Proto2OneofIgnoreEmptyWithDefault {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0,
       default = -42
     ];
@@ -237,7 +237,7 @@ message Proto2RepeatedIgnoreUnspecified {
 
 message Proto2RepeatedIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
@@ -255,7 +255,7 @@ message Proto2MapIgnoreUnspecified {
 
 message Proto2MapIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }
@@ -273,7 +273,7 @@ message Proto2RepeatedItemIgnoreUnspecified {
 
 message Proto2RepeatedItemIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).repeated.items.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).repeated.items.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.items.int32.gt = 0
   ];
 }
@@ -291,7 +291,7 @@ message Proto2MapKeyIgnoreUnspecified {
 
 message Proto2MapKeyIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.keys.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.keys.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.keys.int32.gt = 0
   ];
 }
@@ -309,7 +309,7 @@ message Proto2MapValueIgnoreUnspecified {
 
 message Proto2MapValueIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.values.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.values.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.values.int32.gt = 0
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto3.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto3.proto
@@ -24,7 +24,7 @@ message Proto3ScalarOptionalIgnoreUnspecified {
 
 message Proto3ScalarOptionalIgnoreEmpty {
   optional int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -42,7 +42,7 @@ message Proto3ScalarIgnoreUnspecified {
 
 message Proto3ScalarIgnoreEmpty {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -67,7 +67,7 @@ message Proto3MessageOptionalIgnoreUnspecified {
 
 message Proto3MessageOptionalIgnoreEmpty {
   optional Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto3.message.ignore.empty"
       message: "foobar"
@@ -106,7 +106,7 @@ message Proto3MessageIgnoreUnspecified {
 
 message Proto3MessageIgnoreEmpty {
   Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto3.message.ignore.empty"
       message: "foobar"
@@ -127,7 +127,7 @@ message Proto3OneofIgnoreUnspecified {
 message Proto3OneofIgnoreEmpty {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -148,7 +148,7 @@ message Proto3RepeatedIgnoreUnspecified {
 
 message Proto3RepeatedIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
@@ -166,7 +166,7 @@ message Proto3MapIgnoreUnspecified {
 
 message Proto3MapIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }
@@ -184,7 +184,7 @@ message Proto3RepeatedItemIgnoreUnspecified {
 
 message Proto3RepeatedItemIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).repeated.items.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).repeated.items.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.items.int32.gt = 0
   ];
 }
@@ -202,7 +202,7 @@ message Proto3MapKeyIgnoreUnspecified {
 
 message Proto3MapKeyIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.keys.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.keys.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.keys.int32.gt = 0
   ];
 }
@@ -220,7 +220,7 @@ message Proto3MapValueIgnoreUnspecified {
 
 message Proto3MapValueIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.values.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.values.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.values.int32.gt = 0
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto_editions.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/ignore_proto_editions.proto
@@ -31,14 +31,14 @@ message EditionsScalarExplicitPresenceIgnoreUnspecifiedWithDefault {
 
 message EditionsScalarExplicitPresenceIgnoreEmpty {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
 
 message EditionsScalarExplicitPresenceIgnoreEmptyWithDefault {
   int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = -42
   ];
@@ -69,7 +69,7 @@ message EditionsScalarImplicitPresenceIgnoreUnspecified {
 message EditionsScalarImplicitPresenceIgnoreEmpty {
   int32 val = 1 [
     features.field_presence = IMPLICIT,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -100,7 +100,7 @@ message EditionsScalarLegacyRequiredIgnoreUnspecifiedWithDefault {
 message EditionsScalarLegacyRequiredIgnoreEmpty {
   int32 val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0
   ];
 }
@@ -108,7 +108,7 @@ message EditionsScalarLegacyRequiredIgnoreEmpty {
 message EditionsScalarLegacyRequiredIgnoreEmptyWithDefault {
   int32 val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).int32.gt = 0,
     default = -42
   ];
@@ -158,7 +158,7 @@ message EditionsMessageExplicitPresenceDelimitedIgnoreUnspecified {
 
 message EditionsMessageExplicitPresenceIgnoreEmpty {
   Msg val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto.editions.message.ignore.empty"
       message: "foobar"
@@ -173,7 +173,7 @@ message EditionsMessageExplicitPresenceIgnoreEmpty {
 message EditionsMessageExplicitPresenceDelimitedIgnoreEmpty {
   Msg val = 1 [
     features.message_encoding = DELIMITED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto.editions.message.ignore.empty"
       message: "foobar"
@@ -246,7 +246,7 @@ message EditionsMessageLegacyRequiredDelimitedIgnoreUnspecified {
 message EditionsMessageLegacyRequiredIgnoreEmpty {
   Msg val = 1 [
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto.editions.message.ignore.empty"
       message: "foobar"
@@ -262,7 +262,7 @@ message EditionsMessageLegacyRequiredDelimitedIgnoreEmpty {
   Msg val = 1 [
     features.message_encoding = DELIMITED,
     features.field_presence = LEGACY_REQUIRED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).cel = {
       id: "proto.editions.message.ignore.empty"
       message: "foobar"
@@ -323,7 +323,7 @@ message EditionsOneofIgnoreUnspecifiedWithDefault {
 message EditionsOneofIgnoreEmpty {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0
     ];
   }
@@ -332,7 +332,7 @@ message EditionsOneofIgnoreEmpty {
 message EditionsOneofIgnoreEmptyWithDefault {
   oneof o {
     int32 val = 1 [
-      (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
       (buf.validate.field).int32.gt = 0,
       default = -42
     ];
@@ -371,7 +371,7 @@ message EditionsRepeatedExpandedIgnoreUnspecified {
 
 message EditionsRepeatedIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
@@ -379,7 +379,7 @@ message EditionsRepeatedIgnoreEmpty {
 message EditionsRepeatedExpandedIgnoreEmpty {
   repeated int32 val = 1 [
     features.repeated_field_encoding = EXPANDED,
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.min_items = 3
   ];
 }
@@ -405,7 +405,7 @@ message EditionsMapIgnoreUnspecified {
 
 message EditionsMapIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.min_pairs = 3
   ];
 }
@@ -430,7 +430,7 @@ message EditionsRepeatedExpandedItemIgnoreUnspecified {
 
 message EditionsRepeatedItemIgnoreEmpty {
   repeated int32 val = 1 [
-    (buf.validate.field).repeated.items.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).repeated.items.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.items.int32.gt = 0
   ];
 }
@@ -438,7 +438,7 @@ message EditionsRepeatedItemIgnoreEmpty {
 message EditionsRepeatedExpandedItemIgnoreEmpty {
   repeated int32 val = 1 [
     features.repeated_field_encoding = EXPANDED,
-    (buf.validate.field).repeated.items.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).repeated.items.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).repeated.items.int32.gt = 0
   ];
 }
@@ -464,7 +464,7 @@ message EditionsMapKeyIgnoreUnspecified {
 
 message EditionsMapKeyIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.keys.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.keys.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.keys.int32.gt = 0
   ];
 }
@@ -482,7 +482,7 @@ message EditionsMapValueIgnoreUnspecified {
 
 message EditionsMapValueIgnoreEmpty {
   map<int32, int32> val = 1 [
-    (buf.validate.field).map.values.ignore = IGNORE_IF_UNPOPULATED,
+    (buf.validate.field).map.values.ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).map.values.int32.gt = 0
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/maps.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/maps.proto
@@ -68,7 +68,7 @@ message MapExactIgnore {
       min_pairs: 3
       max_pairs: 3
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/numbers.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/numbers.proto
@@ -85,7 +85,7 @@ message FloatIgnore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -164,7 +164,7 @@ message DoubleIgnore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -237,7 +237,7 @@ message Int32Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -310,7 +310,7 @@ message Int64Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 message Int64BigRules {
@@ -408,7 +408,7 @@ message UInt32Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -481,7 +481,7 @@ message UInt64Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -554,7 +554,7 @@ message SInt32Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -627,7 +627,7 @@ message SInt64Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 message SInt64IncorrectType {
@@ -699,7 +699,7 @@ message Fixed32Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -772,7 +772,7 @@ message Fixed64Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -845,7 +845,7 @@ message SFixed32Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 
@@ -918,7 +918,7 @@ message SFixed64Ignore {
       gte: 128
       lte: 256
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/repeated.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/repeated.proto
@@ -161,6 +161,6 @@ message RepeatedExactIgnore {
       min_items: 3
       max_items: 3
     },
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/strings.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/strings.proto
@@ -220,7 +220,7 @@ message StringHttpHeaderValueLoose {
 message StringUUIDIgnore {
   string val = 1 [
     (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
 }
 message StringInOneof {

--- a/proto/protovalidate-testing/tests/migrate/field_ignore_empty.migrated.proto
+++ b/proto/protovalidate-testing/tests/migrate/field_ignore_empty.migrated.proto
@@ -21,7 +21,7 @@ import "validate/validate.proto";
 import "buf/validate/validate.proto";
 
 message FieldIgnoreEmpty {
-  int32 x = 1 [(validate.rules).int32.ignore_empty = true,(buf.validate.field).ignore = IGNORE_IF_UNPOPULATED];
+  int32 x = 1 [(validate.rules).int32.ignore_empty = true,(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE];
   string y = 2 [
     (validate.rules).int32 = { ignore_empty: false },
     (buf.validate.field).int32 = { }
@@ -32,7 +32,7 @@ message FieldIgnoreEmpty {
     },
     (buf.validate.field).repeated.items = {
       int32: { gt: 10 }
-      , ignore: IGNORE_IF_UNPOPULATED;
+      , ignore: IGNORE_IF_ZERO_VALUE;
     }
   ];
 }

--- a/proto/protovalidate-testing/tests/migrate/field_ignore_skip.migrated.proto
+++ b/proto/protovalidate-testing/tests/migrate/field_ignore_skip.migrated.proto
@@ -29,7 +29,7 @@ message IgnoreAndSkips {
     (buf.validate.field).string = {
       pattern: '^a+$',
     }
-    , (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    , (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
   repeated string y = 2 [
     (validate.rules).repeated = {
@@ -41,7 +41,7 @@ message IgnoreAndSkips {
       unique: true,
       items: { string: { in: ['a', 'b'] } }
     }
-    , (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
+    , (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
   ];
   IgnoreAndSkips z = 3 [
     (validate.rules).message = { skip: true },

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -145,7 +145,7 @@ message MessageRules {
   //      silently ignored when unmarshalling, with only the last field being set when
   //      unmarshalling completes.
   //
-  // Note that adding a field to a `oneof` will also set the IGNORE_IF_UNPOPULATED on the fields. This means
+  // Note that adding a field to a `oneof` will also set the IGNORE_IF_ZERO_VALUE on the fields. This means
   // only the field that is set will be validated and the unset fields are not validated according to the field rules.
   // This behavior can be overridden by setting `ignore` against a field.
   //
@@ -393,53 +393,21 @@ enum Ignore {
   // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
   IGNORE_UNSPECIFIED = 0;
 
-  // Ignore rules if the field is unset, also for fields that don't track
-  // presence.
+  // Ignore rules if the field is unset, or set to the zero value.
   //
-  // In proto3, repeated fields, map fields, and fields with scalar types don't
-  // track presence. Consequently, the following fields are only validated if
-  // they are set:
-  //
-  // ```proto
-  // syntax="proto3";
-  //
-  // message RulesApplyIfSet {
-  //   // `string.email` is ignored for the empty string.
-  //   string link = 1 [
-  //     (buf.validate.field).string.email = true,
-  //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-  //   ];
-  //   // `int32.gte` is ignored for the zero value.
-  //   int32 age = 2 [
-  //     (buf.validate.field).int32.gte = 21,
-  //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-  //   ];
-  //   // `repeated.min_items` is ignored if the list is empty.
-  //   repeated string labels = 3 [
-  //     (buf.validate.field).repeated.min_items = 3,
-  //     (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-  //   ];
-  // }
-  // ```
-  //
-  // For fields that don't track presence, the field's value determines
-  // whether the field is set and rules apply:
-  //
-  // - For string and bytes, an empty value is ignored.
-  // - For bool, false is ignored.
-  // - For numeric types, zero is ignored.
-  // - For enums, the first defined enum value is ignored.
-  // - For repeated fields, an empty list is ignored.
-  // - For map fields, an empty map is ignored.
-  // - For message fields, absence of the message (typically a null-value) is
-  //   ignored.
+  // The zero value depends on the field type:
+  // - For strings, the zero value is the empty string.
+  // - For bytes, the zero value is empty bytes.
+  // - For bool, the zero value is false.
+  // - For numeric types, the zero value is zero.
+  // - For enums, the zero value is the first defined enum value.
+  // - For repeated fields, the zero is an empty list.
+  // - For map fields, the zero is an empty map.
+  // - For message fields, absence of the message (typically a null-value) is considered zero value.
   //
   // For fields that track presence (e.g. adding the `optional` label in proto3),
-  // behavior is the same as the default `IGNORE_UNSPECIFIED`.
-  //
-  // To learn which fields track presence, see the
-  // [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
-  IGNORE_IF_UNPOPULATED = 1;
+  // this a no-op and behavior is the same as the default `IGNORE_UNSPECIFIED`.
+  IGNORE_IF_ZERO_VALUE = 1;
 
   // Always ignore rules, including the `required` rule.
   //
@@ -457,7 +425,7 @@ enum Ignore {
   IGNORE_ALWAYS = 3;
 
   reserved 2;
-  reserved "IGNORE_EMPTY", "IGNORE_DEFAULT", "IGNORE_IF_DEFAULT_VALUE";
+  reserved "IGNORE_EMPTY", "IGNORE_DEFAULT", "IGNORE_IF_DEFAULT_VALUE", "IGNORE_IF_UNPOPULATED";
 }
 
 // FloatRules describes the rules applied to `float` values. These

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -97,54 +97,21 @@ const (
 	// To learn which fields track presence, see the
 	// [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
 	Ignore_IGNORE_UNSPECIFIED Ignore = 0
-	// Ignore rules if the field is unset, also for fields that don't track
-	// presence.
+	// Ignore rules if the field is unset, or set to the zero value.
 	//
-	// In proto3, repeated fields, map fields, and fields with scalar types don't
-	// track presence. Consequently, the following fields are only validated if
-	// they are set:
-	//
-	// ```proto
-	// syntax="proto3";
-	//
-	//	message RulesApplyIfSet {
-	//	  // `string.email` is ignored for the empty string.
-	//	  string link = 1 [
-	//	    (buf.validate.field).string.email = true,
-	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-	//	  ];
-	//	  // `int32.gte` is ignored for the zero value.
-	//	  int32 age = 2 [
-	//	    (buf.validate.field).int32.gte = 21,
-	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-	//	  ];
-	//	  // `repeated.min_items` is ignored if the list is empty.
-	//	  repeated string labels = 3 [
-	//	    (buf.validate.field).repeated.min_items = 3,
-	//	    (buf.validate.field).ignore = IGNORE_IF_UNPOPULATED
-	//	  ];
-	//	}
-	//
-	// ```
-	//
-	// For fields that don't track presence, the field's value determines
-	// whether the field is set and rules apply:
-	//
-	//   - For string and bytes, an empty value is ignored.
-	//   - For bool, false is ignored.
-	//   - For numeric types, zero is ignored.
-	//   - For enums, the first defined enum value is ignored.
-	//   - For repeated fields, an empty list is ignored.
-	//   - For map fields, an empty map is ignored.
-	//   - For message fields, absence of the message (typically a null-value) is
-	//     ignored.
+	// The zero value depends on the field type:
+	// - For strings, the zero value is the empty string.
+	// - For bytes, the zero value is empty bytes.
+	// - For bool, the zero value is false.
+	// - For numeric types, the zero value is zero.
+	// - For enums, the zero value is the first defined enum value.
+	// - For repeated fields, the zero is an empty list.
+	// - For map fields, the zero is an empty map.
+	// - For message fields, absence of the message (typically a null-value) is considered zero value.
 	//
 	// For fields that track presence (e.g. adding the `optional` label in proto3),
-	// behavior is the same as the default `IGNORE_UNSPECIFIED`.
-	//
-	// To learn which fields track presence, see the
-	// [Field Presence cheat sheet](https://protobuf.dev/programming-guides/field_presence/#cheat).
-	Ignore_IGNORE_IF_UNPOPULATED Ignore = 1
+	// this a no-op and behavior is the same as the default `IGNORE_UNSPECIFIED`.
+	Ignore_IGNORE_IF_ZERO_VALUE Ignore = 1
 	// Always ignore rules, including the `required` rule.
 	//
 	// This is useful for ignoring the rules of a referenced message, or to
@@ -167,13 +134,13 @@ const (
 var (
 	Ignore_name = map[int32]string{
 		0: "IGNORE_UNSPECIFIED",
-		1: "IGNORE_IF_UNPOPULATED",
+		1: "IGNORE_IF_ZERO_VALUE",
 		3: "IGNORE_ALWAYS",
 	}
 	Ignore_value = map[string]int32{
-		"IGNORE_UNSPECIFIED":    0,
-		"IGNORE_IF_UNPOPULATED": 1,
-		"IGNORE_ALWAYS":         3,
+		"IGNORE_UNSPECIFIED":   0,
+		"IGNORE_IF_ZERO_VALUE": 1,
+		"IGNORE_ALWAYS":        3,
 	}
 )
 
@@ -403,7 +370,7 @@ type MessageRules struct {
 	//     silently ignored when unmarshalling, with only the last field being set when
 	//     unmarshalling completes.
 	//
-	// Note that adding a field to a `oneof` will also set the IGNORE_IF_UNPOPULATED on the fields. This means
+	// Note that adding a field to a `oneof` will also set the IGNORE_IF_ZERO_VALUE on the fields. This means
 	// only the field that is set will be validated and the unset fields are not validated according to the field rules.
 	// This behavior can be overridden by setting `ignore` against a field.
 	//
@@ -8463,11 +8430,11 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\n" +
 	"string_key\x18\n" +
 	" \x01(\tH\x00R\tstringKeyB\v\n" +
-	"\tsubscript*\x8b\x01\n" +
+	"\tsubscript*\xa1\x01\n" +
 	"\x06Ignore\x12\x16\n" +
-	"\x12IGNORE_UNSPECIFIED\x10\x00\x12\x19\n" +
-	"\x15IGNORE_IF_UNPOPULATED\x10\x01\x12\x11\n" +
-	"\rIGNORE_ALWAYS\x10\x03\"\x04\b\x02\x10\x02*\fIGNORE_EMPTY*\x0eIGNORE_DEFAULT*\x17IGNORE_IF_DEFAULT_VALUE*n\n" +
+	"\x12IGNORE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14IGNORE_IF_ZERO_VALUE\x10\x01\x12\x11\n" +
+	"\rIGNORE_ALWAYS\x10\x03\"\x04\b\x02\x10\x02*\fIGNORE_EMPTY*\x0eIGNORE_DEFAULT*\x17IGNORE_IF_DEFAULT_VALUE*\x15IGNORE_IF_UNPOPULATED*n\n" +
 	"\n" +
 	"KnownRegex\x12\x1b\n" +
 	"\x17KNOWN_REGEX_UNSPECIFIED\x10\x00\x12 \n" +

--- a/tools/protovalidate-migrate/internal/migrator/field.go
+++ b/tools/protovalidate-migrate/internal/migrator/field.go
@@ -154,7 +154,7 @@ func (v *FieldVisitor) buildNameParts(node *ast.OptionNode) (nameParts []ast.Nod
 		case "ignore_empty":
 			// moved up & renamed, drop the parent element from the path
 			nameParts = append(nameParts[:len(nameParts)-2], dot, v.replaceNode(part, "ignore"))
-			value = v.replaceNode(value, validate.Ignore_IGNORE_IF_UNPOPULATED.String())
+			value = v.replaceNode(value, validate.Ignore_IGNORE_IF_ZERO_VALUE.String())
 		case "required":
 			switch node.Name.Parts[i].Value() {
 			case "any", "timestamp", "duration":
@@ -259,7 +259,7 @@ func (v *MessageLiteralVisitor) VisitMessageFieldNode(node *ast.MessageFieldNode
 		name = v.replaceNode(name, "ignore")
 	case "ignore_empty":
 		if val, ok := node.Val.Value().(ast.Identifier); ok && val == "true" {
-			v.ignoreNeeded = v.replaceNode(node.Val, validate.Ignore_IGNORE_IF_UNPOPULATED.String())
+			v.ignoreNeeded = v.replaceNode(node.Val, validate.Ignore_IGNORE_IF_ZERO_VALUE.String())
 		}
 		v.wroteItem = false
 		return nil


### PR DESCRIPTION
`IGNORE_IF_UNPOPULATED` is a no-op for fields that track presence. It behaves the same as the default for them, and is only useful for fields that don't track presence. It reads "unpopulated" for fields that don't have a logical unpopulated state, yet it is only relevant for them. This is confusing.

To address this we are renaming the field to `IGNORE_IF_ZERO_VALUE` along with a note to indicate it is a no-op for fields that track presence. 

While this is a breaking change, there is no change in the behavior. Migrating is as simple as updating all occurrences of `IGNORE_IF_UNPOPULATED` to `IGNORE_IF_ZERO_VALUE` and everything will continue to work as it was working before.