### PR TITLE
Changing links to use protovalidate.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ message User {
 
 ## Supported languages
 
-To start using Protovalidate in your projects, see the [developer quickstart][quickstart], [Protovalidate overview][protovalidate], or go directly to the repository for your language of choice:
+To start using Protovalidate in your projects, see the [developer quickstart][quickstart], [Protovalidate overview][protovalidate-overview], or go directly to the repository for your language of choice:
 
 - [`protovalidate-go`][pv-go] (Go)
 - [`protovalidate-java`][pv-java] (Java)
@@ -82,6 +82,7 @@ Offered under the [Apache 2 license][license].
 [ci]: https://github.com/bufbuild/protovalidate/actions/workflows/ci.yaml
 
 [protovalidate]: https://protovalidate.com/
+[protovalidate-overview]: https://protovalidate.com/about/
 [quickstart]: https://protovalidate.com/quickstart/
 [connect-go]: https://protovalidate.com/quickstart/connect-go/
 [grpc-go]: https://protovalidate.com/quickstart/grpc-go/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To start using Protovalidate in your projects, see the [developer quickstart][qu
 
 ## Documentation
 
-Comprehensive documentation for Protovalidate is available in [Buf's documentation library][protovalidate].
+Comprehensive documentation for Protovalidate at [protovalidate.com][protovalidate].
 
 Highlights include:
 
@@ -81,10 +81,10 @@ Offered under the [Apache 2 license][license].
 [conformance]: https://github.com/bufbuild/protovalidate/blob/main/docs/conformance.md
 [ci]: https://github.com/bufbuild/protovalidate/actions/workflows/ci.yaml
 
-[protovalidate]: https://buf.build/docs/protovalidate/
-[quickstart]: https://buf.build/docs/protovalidate/quickstart/
-[connect-go]: https://buf.build/docs/protovalidate/quickstart/connect-go/
-[grpc-go]: https://buf.build/docs/protovalidate/quickstart/grpc-go/
-[grpc-java]: https://buf.build/docs/protovalidate/quickstart/grpc-java/
-[grpc-python]: https://buf.build/docs/protovalidate/quickstart/grpc-python/
+[protovalidate]: .https://protovalidate.com/
+[quickstart]: .https://protovalidate.com/quickstart/
+[connect-go]: .https://protovalidate.com/quickstart/connect-go/
+[grpc-go]: .https://protovalidate.com/quickstart/grpc-go/
+[grpc-java]: .https://protovalidate.com/quickstart/grpc-java/
+[grpc-python]: .https://protovalidate.com/quickstart/grpc-python/
 [migration-guide]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Offered under the [Apache 2 license][license].
 [conformance]: https://github.com/bufbuild/protovalidate/blob/main/docs/conformance.md
 [ci]: https://github.com/bufbuild/protovalidate/actions/workflows/ci.yaml
 
-[protovalidate]: .https://protovalidate.com/
-[quickstart]: .https://protovalidate.com/quickstart/
-[connect-go]: .https://protovalidate.com/quickstart/connect-go/
-[grpc-go]: .https://protovalidate.com/quickstart/grpc-go/
-[grpc-java]: .https://protovalidate.com/quickstart/grpc-java/
-[grpc-python]: .https://protovalidate.com/quickstart/grpc-python/
+[protovalidate]: https://protovalidate.com/
+[quickstart]: https://protovalidate.com/quickstart/
+[connect-go]: https://protovalidate.com/quickstart/connect-go/
+[grpc-go]: https://protovalidate.com/quickstart/grpc-go/
+[grpc-java]: https://protovalidate.com/quickstart/grpc-java/
+[grpc-python]: https://protovalidate.com/quickstart/grpc-python/
 [migration-guide]: https://buf.build/docs/migration-guides/migrate-from-protoc-gen-validate/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To start using Protovalidate in your projects, see the [developer quickstart][qu
 
 ## Documentation
 
-Comprehensive documentation for Protovalidate at [protovalidate.com][protovalidate].
+Comprehensive documentation for Protovalidate is available at [protovalidate.com][protovalidate].
 
 Highlights include:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 # Documentation
 
-This page has moved to [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[violation-reference]: https://buf.build/docs/reference/protovalidate/violations/
+[protovalidate]: .https://protovalidate.com/
+[violation-reference]: .https://protovalidate.com/reference/violations/

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,5 @@
 This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[violation-reference]: .https://protovalidate.com/reference/violations/
+[protovalidate]: https://protovalidate.com/
+[violation-reference]: https://protovalidate.com/reference/violations/

--- a/docs/cel.md
+++ b/docs/cel.md
@@ -6,7 +6,7 @@
 
 ## Learn more about CEL in Protovalidate
 
-Learn more about using CEL in [Protovalidate's documentation][protovalidate]:
+Learn more about using CEL at [protovalidate.com][protovalidate]:
 
 - Write [custom rules][custom-rules] for messages or fields.
 - Create reusable [predefined rules][predefined-rules].
@@ -21,10 +21,10 @@ Protovalidate CEL expressions can use the entire CEL standard library, including
 - CEL's standard [macros](https://github.com/google/cel-spec/blob/v0.8.0/doc/langdef.md#macros)
 - CEL's [extended string function library](https://pkg.go.dev/github.com/google/cel-go/ext#Strings)
 
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/
 [cel]: https://cel.dev
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
-[predefined-rules]: https://buf.build/docs/protovalidate/schemas/predefined-rules/
-[cel-extensions]: https://buf.build/docs/reference/protovalidate/cel_extensions/
-[advanced-cel]: https://buf.build/docs/protovalidate/cel/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
+[cel-extensions]: .https://protovalidate.com/reference/cel_extensions/
+[advanced-cel]: .https://protovalidate.com/cel/

--- a/docs/cel.md
+++ b/docs/cel.md
@@ -21,10 +21,10 @@ Protovalidate CEL expressions can use the entire CEL standard library, including
 - CEL's standard [macros](https://github.com/google/cel-spec/blob/v0.8.0/doc/langdef.md#macros)
 - CEL's [extended string function library](https://pkg.go.dev/github.com/google/cel-go/ext#Strings)
 
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/
 [cel]: https://cel.dev
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
-[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
-[cel-extensions]: .https://protovalidate.com/reference/cel_extensions/
-[advanced-cel]: .https://protovalidate.com/cel/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/
+[predefined-rules]: https://protovalidate.com/schemas/predefined-rules/
+[cel-extensions]: https://protovalidate.com/reference/cel_extensions/
+[advanced-cel]: https://protovalidate.com/cel/

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -2,8 +2,8 @@
 
 # Custom rules
 
-This page has moved to [custom rules][custom-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [custom rules][custom-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
+[protovalidate]: .https://protovalidate.com/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -5,5 +5,5 @@
 This page has moved to [custom rules][custom-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[protovalidate]: https://protovalidate.com/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -5,5 +5,5 @@
 This page has moved to the [violation reference][violation-reference] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[violation-reference]: .https://protovalidate.com/reference/violations/
+[protovalidate]: https://protovalidate.com/
+[violation-reference]: https://protovalidate.com/reference/violations/

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -2,8 +2,8 @@
 
 # Rule violations
 
-This page has moved to the [violation reference][violation-reference] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to the [violation reference][violation-reference] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[violation-reference]: https://buf.build/docs/reference/protovalidate/violations/
+[protovalidate]: .https://protovalidate.com/
+[violation-reference]: .https://protovalidate.com/reference/violations/

--- a/docs/predefined-rules.md
+++ b/docs/predefined-rules.md
@@ -2,8 +2,8 @@
 
 # Predefined rules
 
-This page has been moved to [predefined rules][predefined-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has been moved to [predefined rules][predefined-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[predefined-rules]: https://buf.build/docs/protovalidate/schemas/predefined-rules/
+[protovalidate]: .https://protovalidate.com/
+[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/

--- a/docs/predefined-rules.md
+++ b/docs/predefined-rules.md
@@ -5,5 +5,5 @@
 This page has been moved to [predefined rules][predefined-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[predefined-rules]: .https://protovalidate.com/schemas/predefined-rules/
+[protovalidate]: https://protovalidate.com/
+[predefined-rules]: https://protovalidate.com/schemas/predefined-rules/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,7 +2,7 @@
 
 # Rules
 
-This page has moved to [protovalidate.com][protovalidate].
+This page has moved to [Protovalidate's comprehensive documentation][protovalidate-docs] at [protovalidate.com][protovalidate].
 
-[buf]: https://buf.build
+[protovalidate-docs]: https://protovalidate.com/about/
 [protovalidate]: https://protovalidate.com/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,7 +2,7 @@
 
 # Rules
 
-This page has moved to [Protovalidate's comprehensive documentation][protovalidate] at [Buf][buf].
+This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -5,4 +5,4 @@
 This page has moved to [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/

--- a/docs/standard-rules.md
+++ b/docs/standard-rules.md
@@ -5,5 +5,5 @@
 This page has moved to [standard rules][standard-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[protovalidate]: https://protovalidate.com/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/

--- a/docs/standard-rules.md
+++ b/docs/standard-rules.md
@@ -2,8 +2,8 @@
 
 # Standard rules
 
-This page has moved to [standard rules][standard-rules] within [Protovalidate's documentation][protovalidate] at [Buf][buf].
+This page has moved to [standard rules][standard-rules] at [protovalidate.com][protovalidate].
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
+[protovalidate]: .https://protovalidate.com/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,10 @@ The following direct links can be used to find the examples that used to be in t
 - Discover how CEL-based [custom rules][custom-rules] allow you to express business rules within Protobuf.
 
 [buf]: https://buf.build
-[protovalidate]: https://buf.build/docs/protovalidate/
+[protovalidate]: .https://protovalidate.com/
 [protovalidate-examples]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate
 [standard-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-standard
 [custom-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-custom
-[quickstart]: https://buf.build/docs/protovalidate/quickstart/
-[standard-rules]: https://buf.build/docs/protovalidate/schemas/standard-rules/
-[custom-rules]: https://buf.build/docs/protovalidate/schemas/custom-rules/
+[quickstart]: .https://protovalidate.com/quickstart/
+[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: .https://protovalidate.com/schemas/custom-rules/

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,10 @@ The following direct links can be used to find the examples that used to be in t
 - Discover how CEL-based [custom rules][custom-rules] allow you to express business rules within Protobuf.
 
 [buf]: https://buf.build
-[protovalidate]: .https://protovalidate.com/
+[protovalidate]: https://protovalidate.com/
 [protovalidate-examples]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate
 [standard-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-standard
 [custom-rules-example]: https://github.com/bufbuild/buf-examples/tree/main/protovalidate/rules-custom
-[quickstart]: .https://protovalidate.com/quickstart/
-[standard-rules]: .https://protovalidate.com/schemas/standard-rules/
-[custom-rules]: .https://protovalidate.com/schemas/custom-rules/
+[quickstart]: https://protovalidate.com/quickstart/
+[standard-rules]: https://protovalidate.com/schemas/standard-rules/
+[custom-rules]: https://protovalidate.com/schemas/custom-rules/


### PR DESCRIPTION
Updates all links to buf.build/docs to use protovalidate.com.