### PR TITLE
Fix expected field paths for groups in conformance tests

### DIFF
--- a/tools/protovalidate-conformance/internal/fieldpath/fieldpath.go
+++ b/tools/protovalidate-conformance/internal/fieldpath/fieldpath.go
@@ -83,15 +83,22 @@ func Unmarshal(
 			}
 			descriptor = extension.TypeDescriptor()
 		} else {
-			descriptor = message.Fields().ByTextName(name)
+			descriptor = message.Fields().ByName(protoreflect.Name(name))
 			oneOf = message.Oneofs().ByName(protoreflect.Name(name))
 		}
 		var element *validate.FieldPathElement
 		switch {
-		case descriptor != nil:
+		case isExt:
+
 			element = &validate.FieldPathElement{
 				FieldNumber: proto.Int32(int32(descriptor.Number())),
 				FieldName:   proto.String(descriptor.TextName()),
+				FieldType:   descriptorpb.FieldDescriptorProto_Type(descriptor.Kind()).Enum(),
+			}
+		case descriptor != nil:
+			element = &validate.FieldPathElement{
+				FieldNumber: proto.Int32(int32(descriptor.Number())),
+				FieldName:   proto.String(string(descriptor.Name())),
 				FieldType:   descriptorpb.FieldDescriptorProto_Type(descriptor.Kind()).Enum(),
 			}
 		case oneOf != nil:


### PR DESCRIPTION
https://github.com/bufbuild/protovalidate/pull/439 added tests for proto2 groups and the editions equivalent. 

Unfortunately, the logic to turn field paths specified in tests into `buf.validate.FieldPath`s does not handle groups correctly: For a `group Optional`, we expect a field path element named `"Optional"` but the correct field name is `"optional"`.
