### PR TITLE
Fix field_mask.const rule

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4671,7 +4671,7 @@ message FieldMaskRules {
   // ```
   optional google.protobuf.FieldMask const = 1 [(predefined).cel = {
     id: "field_mask.const"
-    expression: "this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''"
+    expression: "this != getField(rules, 'const') ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''"
   }];
 
   // `in` requires the field value to only contain paths matching specified

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -8578,11 +8578,11 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\x18\n" +
 	"\x10duration.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\xfd\x05\n" +
-	"\x0eFieldMaskRules\x12\xab\x01\n" +
-	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskBy\xc2Hv\n" +
-	"t\n" +
-	"\x10field_mask.const\x1a`this != getField(rules, 'const') ? 'value must equal %s'.format([getField(rules, 'const')]) : ''R\x05const\x12\xdd\x01\n" +
+	"\fgreater_than\"\x8c\x06\n" +
+	"\x0eFieldMaskRules\x12\xba\x01\n" +
+	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x87\x01\xc2H\x83\x01\n" +
+	"\x80\x01\n" +
+	"\x10field_mask.const\x1althis != getField(rules, 'const') ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''R\x05const\x12\xdd\x01\n" +
 	"\x02in\x18\x02 \x03(\tB\xcc\x01\xc2H\xc8\x01\n" +
 	"\xc5\x01\n" +
 	"\rfield_mask.in\x1a\xb3\x01!this.paths.all(p, p in getField(rules, 'in') || getField(rules, 'in').exists(f, p.startsWith(f+'.'))) ? 'value must only contain paths in %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\xfa\x01\n" +

--- a/tools/protovalidate-conformance/internal/cases/cases_field_mask.go
+++ b/tools/protovalidate-conformance/internal/cases/cases_field_mask.go
@@ -62,7 +62,7 @@ func fieldMaskSuite() suites.Suite {
 				Field:   results.FieldPath("val"),
 				Rule:    results.FieldPath("field_mask.const"),
 				RuleId:  proto.String("field_mask.const"),
-				Message: proto.String("value must equal a"),
+				Message: proto.String("value must equal paths [a]"),
 			}),
 		},
 		"in/valid": {


### PR DESCRIPTION
https://github.com/bufbuild/protovalidate/pull/429 added rules for field masks. This PR fixes two issues with `field_mask.const`:

-  The validation expression passes a `google.protobuf.FieldMask` to the CEL function string.format. The function does not support this type.
- The test `standard_rules/well_known_types/field_mask/const/invalid` expected the wrong error message.