### PR TITLE
Update field_mask.const expression to avoid descriptor confusion

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4706,7 +4706,7 @@ message FieldMaskRules {
   // ```
   optional google.protobuf.FieldMask const = 1 [(predefined).cel = {
     id: "field_mask.const"
-    expression: "this != getField(rules, 'const') ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''"
+    expression: "this.paths != getField(rules, 'const').paths ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''"
   }];
 
   // `in` requires the field value to only contain paths matching specified

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -8633,11 +8633,11 @@ const file_buf_validate_validate_proto_rawDesc = "" +
 	"\x18\n" +
 	"\x10duration.example\x1a\x04trueR\aexample*\t\b\xe8\a\x10\x80\x80\x80\x80\x02B\v\n" +
 	"\tless_thanB\x0e\n" +
-	"\fgreater_than\"\x8c\x06\n" +
-	"\x0eFieldMaskRules\x12\xba\x01\n" +
-	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x87\x01\xc2H\x83\x01\n" +
-	"\x80\x01\n" +
-	"\x10field_mask.const\x1althis != getField(rules, 'const') ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''R\x05const\x12\xdd\x01\n" +
+	"\fgreater_than\"\x98\x06\n" +
+	"\x0eFieldMaskRules\x12\xc6\x01\n" +
+	"\x05const\x18\x01 \x01(\v2\x1a.google.protobuf.FieldMaskB\x93\x01\xc2H\x8f\x01\n" +
+	"\x8c\x01\n" +
+	"\x10field_mask.const\x1axthis.paths != getField(rules, 'const').paths ? 'value must equal paths %s'.format([getField(rules, 'const').paths]) : ''R\x05const\x12\xdd\x01\n" +
 	"\x02in\x18\x02 \x03(\tB\xcc\x01\xc2H\xc8\x01\n" +
 	"\xc5\x01\n" +
 	"\rfield_mask.in\x1a\xb3\x01!this.paths.all(p, p in getField(rules, 'in') || getField(rules, 'in').exists(f, p.startsWith(f+'.'))) ? 'value must only contain paths in %s'.format([getField(rules, 'in')]) : ''R\x02in\x12\xfa\x01\n" +


### PR DESCRIPTION
https://github.com/bufbuild/protovalidate/pull/429 added rules for field masks. In the rule `field_mask.const`, we're comparing two `google.protobuf.FieldMask` messages against each other with the CEL expression `this != getField(rules, 'const')`. This comparison is susceptible to type confusion in some Protobuf / CEL implementations. 

For example, protovalidate-go references the descriptor from `fieldmaskpb` when providing the value to CEL, but the user may provide a different instance of the field mask descriptor when validating a message. This results in a false negative when the two messages are compared by cel-go (see its behavior [here](https://github.com/google/cel-go/blob/v0.26.1/common/types/pb/equal.go#L30)). 

To mitigate the problem, this PR changes the CEL expression to compare field mask paths instead of field mask messages.
