### PR TITLE
Enable BSR push

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -15,3 +15,4 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
+          push: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          push: ${{ github.ref != 'refs/heads/main' && github.event_name == 'push'  }}
+          push: ${{ github.ref != 'refs/heads/main' && github.event_name == 'push' }}

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -15,4 +15,4 @@ jobs:
       - uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          push: ${{ github.ref != 'refs/heads/main' }}
+          push: ${{ github.ref != 'refs/heads/main' && github.event_name == 'push'  }}

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -14,6 +14,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: bufbuild/buf-action@v1
         with:
-          # Push and archive are disabled because Protovalidate is managed in https://github.com/bufbuild/modules
-          push: false
-          archive: false
+          token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
This enables pushing to the BSR. Managed modules only push releases. This will make it so that every commit is available on the BSR. This helps with developing/testing features as they are added to protovalidate between releases. For example, the protovalidate-go uses generated SDKs and without the intermediate commits on BSR, it is impossible to get the updated gen code.