### PR TITLE
Fix Duration doc examples to use message literal syntax

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -4458,7 +4458,7 @@ message DurationRules {
   // ```proto
   // message MyDuration {
   //   // value must equal 5s
-  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
+  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = { seconds: 5 }];
   // }
   // ```
   optional google.protobuf.Duration const = 2 [(predefined).cel = {
@@ -4473,7 +4473,7 @@ message DurationRules {
     // ```proto
     // message MyDuration {
     //   // must be less than 5s
-    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
+    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = { seconds: 5 }];
     // }
     // ```
     google.protobuf.Duration lt = 3 [(predefined).cel = {
@@ -4490,7 +4490,7 @@ message DurationRules {
     // ```proto
     // message MyDuration {
     //   // must be less than or equal to 10s
-    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
+    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = { seconds: 10 }];
     // }
     // ```
     google.protobuf.Duration lte = 4 [(predefined).cel = {
@@ -4611,7 +4611,9 @@ message DurationRules {
   // ```proto
   // message MyDuration {
   //   // must be in list [1s, 2s, 3s]
-  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
+  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration = {
+  //     in: [{ seconds: 1 }, { seconds: 2 }, { seconds: 3 }]
+  //   }];
   // }
   // ```
   repeated google.protobuf.Duration in = 7 [(predefined).cel = {
@@ -4627,7 +4629,9 @@ message DurationRules {
   // ```proto
   // message MyDuration {
   //   // value must not be in list [1s, 2s, 3s]
-  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
+  //   google.protobuf.Duration value = 1 [(buf.validate.field).duration = {
+  //     not_in: [{ seconds: 1 }, { seconds: 2 }, { seconds: 3 }]
+  //   }];
   // }
   // ```
   repeated google.protobuf.Duration not_in = 8 [(predefined).cel = {

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -6591,7 +6591,7 @@ type DurationRules struct {
 	//
 	//	message MyDuration {
 	//	  // value must equal 5s
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = { seconds: 5 }];
 	//	}
 	//
 	// ```
@@ -6614,7 +6614,9 @@ type DurationRules struct {
 	//
 	//	message MyDuration {
 	//	  // must be in list [1s, 2s, 3s]
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration = {
+	//	    in: [{ seconds: 1 }, { seconds: 2 }, { seconds: 3 }]
+	//	  }];
 	//	}
 	//
 	// ```
@@ -6628,7 +6630,9 @@ type DurationRules struct {
 	//
 	//	message MyDuration {
 	//	  // value must not be in list [1s, 2s, 3s]
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration = {
+	//	    not_in: [{ seconds: 1 }, { seconds: 2 }, { seconds: 3 }]
+	//	  }];
 	//	}
 	//
 	// ```
@@ -6774,7 +6778,7 @@ type DurationRules_Lt struct {
 	//
 	//	message MyDuration {
 	//	  // must be less than 5s
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = { seconds: 5 }];
 	//	}
 	//
 	// ```
@@ -6790,7 +6794,7 @@ type DurationRules_Lte struct {
 	//
 	//	message MyDuration {
 	//	  // must be less than or equal to 10s
-	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
+	//	  google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = { seconds: 10 }];
 	//	}
 	//
 	// ```


### PR DESCRIPTION
The `const`, `lt`, `lte`, `in`, and `not_in` examples in `DurationRules` showed string values like `5s`, which do not compile for `google.protobuf.Duration`-valued option fields. Replace them with message literal syntax matching the other correct example docs.

Fixes #499