### PR TITLE
Fix additional protovalidate doc examples

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -88,7 +88,7 @@ extend google.protobuf.FieldOptions {
   //
   // ```proto
   // extend buf.validate.Int32Rules {
-  //   bool is_zero [(buf.validate.predefined).cel = {
+  //   bool is_zero = 1001 [(buf.validate.predefined).cel = {
   //     id: "int32.is_zero",
   //     message: "must be zero",
   //     expression: "!rule || this == 0",
@@ -1747,7 +1747,7 @@ message UInt64Rules {
   // message MyUInt64 {
   //   uint64 value = 1 [
   //     (buf.validate.field).uint64.example = 1,
-  //     (buf.validate.field).uint64.example = -10
+  //     (buf.validate.field).uint64.example = 10
   //   ];
   // }
   // ```
@@ -3028,8 +3028,8 @@ message BoolRules {
   // ```proto
   // message MyBool {
   //   bool value = 1 [
-  //     (buf.validate.field).bool.example = 1,
-  //     (buf.validate.field).bool.example = 2
+  //     (buf.validate.field).bool.example = true,
+  //     (buf.validate.field).bool.example = false
   //   ];
   // }
   // ```
@@ -3239,7 +3239,7 @@ message StringRules {
   // ```proto
   // message MyString {
   //   // must be in list ["apple", "banana"]
-  //   string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+  //   string value = 1 [(buf.validate.field).string = { in: ["apple", "banana"] }];
   // }
   // ```
   repeated string in = 10 [(predefined).cel = {
@@ -3253,7 +3253,7 @@ message StringRules {
   // ```proto
   // message MyString {
   //   // value must not be in list ["orange", "grape"]
-  //   string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+  //   string value = 1 [(buf.validate.field).string = { not_in: ["orange", "grape"] }];
   // }
   // ```
   repeated string not_in = 11 [(predefined).cel = {
@@ -4025,7 +4025,7 @@ message BytesRules {
   // ```proto
   // message MyBytes {
   //   // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  //   optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  //   optional bytes value = 1 [(buf.validate.field).bytes = { in: ["\x01\x02", "\x02\x03", "\x03\x04"] }];
   // }
   // ```
   repeated bytes in = 8 [(predefined).cel = {
@@ -4041,7 +4041,7 @@ message BytesRules {
   // ```proto
   // message MyBytes {
   //   // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  //   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  //   optional bytes value = 1 [(buf.validate.field).bytes = { not_in: ["\x01\x02", "\x02\x03", "\x03\x04"] }];
   // }
   // ```
   repeated bytes not_in = 9 [(predefined).cel = {
@@ -4258,8 +4258,10 @@ message EnumRules {
   // }
   //
   // message MyMessage {
+  //   MyEnum value = 1 [
   //     (buf.validate.field).enum.example = 1,
   //     (buf.validate.field).enum.example = 2
+  //   ];
   // }
   // ```
   repeated int32 example = 5 [(predefined).cel = {
@@ -4647,7 +4649,7 @@ message DurationRules {
   // message MyDuration {
   //   google.protobuf.Duration value = 1 [
   //     (buf.validate.field).duration.example = { seconds: 1 },
-  //     (buf.validate.field).duration.example = { seconds: 2 },
+  //     (buf.validate.field).duration.example = { seconds: 2 }
   //   ];
   // }
   // ```
@@ -4727,7 +4729,7 @@ message FieldMaskRules {
   // message MyFieldMask {
   //   google.protobuf.FieldMask value = 1 [
   //     (buf.validate.field).field_mask.example = { paths: ["a", "b"] },
-  //     (buf.validate.field).field_mask.example = { paths: ["c.a", "d"] },
+  //     (buf.validate.field).field_mask.example = { paths: ["c.a", "d"] }
   //   ];
   // }
   // ```
@@ -4938,7 +4940,7 @@ message TimestampRules {
   // message MyTimestamp {
   //   google.protobuf.Timestamp value = 1 [
   //     (buf.validate.field).timestamp.example = { seconds: 1672444800 },
-  //     (buf.validate.field).timestamp.example = { seconds: 1672531200 },
+  //     (buf.validate.field).timestamp.example = { seconds: 1672531200 }
   //   ];
   // }
   // ```
@@ -5038,7 +5040,7 @@ message Violation {
   //   bool b = 2 [(buf.validate.field).cel = {
   //     id: "custom_rule",
   //     expression: "!this ? 'b must be true': ''"
-  //   }]
+  //   }];
   // }
   // ```
   //

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -2683,7 +2683,7 @@ type UInt64Rules struct {
 	//	message MyUInt64 {
 	//	  uint64 value = 1 [
 	//	    (buf.validate.field).uint64.example = 1,
-	//	    (buf.validate.field).uint64.example = -10
+	//	    (buf.validate.field).uint64.example = 10
 	//	  ];
 	//	}
 	//
@@ -4572,8 +4572,8 @@ type BoolRules struct {
 	//
 	//	message MyBool {
 	//	  bool value = 1 [
-	//	    (buf.validate.field).bool.example = 1,
-	//	    (buf.validate.field).bool.example = 2
+	//	    (buf.validate.field).bool.example = true,
+	//	    (buf.validate.field).bool.example = false
 	//	  ];
 	//	}
 	//
@@ -4800,7 +4800,7 @@ type StringRules struct {
 	//
 	//	message MyString {
 	//	  // must be in list ["apple", "banana"]
-	//	  string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+	//	  string value = 1 [(buf.validate.field).string = { in: ["apple", "banana"] }];
 	//	}
 	//
 	// ```
@@ -4812,7 +4812,7 @@ type StringRules struct {
 	//
 	//	message MyString {
 	//	  // value must not be in list ["orange", "grape"]
-	//	  string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+	//	  string value = 1 [(buf.validate.field).string = { not_in: ["orange", "grape"] }];
 	//	}
 	//
 	// ```
@@ -5808,7 +5808,7 @@ type BytesRules struct {
 	//
 	//	message MyBytes {
 	//	  // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
-	//	  optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+	//	  optional bytes value = 1 [(buf.validate.field).bytes = { in: ["\x01\x02", "\x02\x03", "\x03\x04"] }];
 	//	}
 	//
 	// ```
@@ -5822,7 +5822,7 @@ type BytesRules struct {
 	//
 	//	message MyBytes {
 	//	  // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
-	//	  optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+	//	  optional bytes value = 1 [(buf.validate.field).bytes = { not_in: ["\x01\x02", "\x02\x03", "\x03\x04"] }];
 	//	}
 	//
 	// ```
@@ -6170,8 +6170,10 @@ type EnumRules struct {
 	//	}
 	//
 	//	message MyMessage {
+	//	  MyEnum value = 1 [
 	//	    (buf.validate.field).enum.example = 1,
 	//	    (buf.validate.field).enum.example = 2
+	//	  ];
 	//	}
 	//
 	// ```
@@ -6646,7 +6648,7 @@ type DurationRules struct {
 	//	message MyDuration {
 	//	  google.protobuf.Duration value = 1 [
 	//	    (buf.validate.field).duration.example = { seconds: 1 },
-	//	    (buf.validate.field).duration.example = { seconds: 2 },
+	//	    (buf.validate.field).duration.example = { seconds: 2 }
 	//	  ];
 	//	}
 	//
@@ -6922,7 +6924,7 @@ type FieldMaskRules struct {
 	//	message MyFieldMask {
 	//	  google.protobuf.FieldMask value = 1 [
 	//	    (buf.validate.field).field_mask.example = { paths: ["a", "b"] },
-	//	    (buf.validate.field).field_mask.example = { paths: ["c.a", "d"] },
+	//	    (buf.validate.field).field_mask.example = { paths: ["c.a", "d"] }
 	//	  ];
 	//	}
 	//
@@ -7037,7 +7039,7 @@ type TimestampRules struct {
 	//	message MyTimestamp {
 	//	  google.protobuf.Timestamp value = 1 [
 	//	    (buf.validate.field).timestamp.example = { seconds: 1672444800 },
-	//	    (buf.validate.field).timestamp.example = { seconds: 1672531200 },
+	//	    (buf.validate.field).timestamp.example = { seconds: 1672531200 }
 	//	  ];
 	//	}
 	//
@@ -7425,7 +7427,7 @@ type Violation struct {
 	//	  bool b = 2 [(buf.validate.field).cel = {
 	//	    id: "custom_rule",
 	//	    expression: "!this ? 'b must be true': ''"
-	//	  }]
+	//	  }];
 	//	}
 	//
 	// ```
@@ -7838,7 +7840,7 @@ var (
 	// ```proto
 	//
 	//	extend buf.validate.Int32Rules {
-	//	  bool is_zero [(buf.validate.predefined).cel = {
+	//	  bool is_zero = 1001 [(buf.validate.predefined).cel = {
 	//	    id: "int32.is_zero",
 	//	    message: "must be zero",
 	//	    expression: "!rule || this == 0",


### PR DESCRIPTION
Fix compilation errors in doc examples and switch string in/not_in to more concise form.