### PR TITLE
Unpin bazel actions to fix release

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -17,12 +17,14 @@
       "github": "jonbodner-buf"
     },
     {
-      "name": "Sri Krishna Paritala",
-      "email": "skrishna@buf.build",
-      "github": "srikrsna-buf"
+      "name": "Philip Warren",
+      "email": "pwarren@buf.build",
+      "github": "pkwarren"
     }
   ],
-  "repository": ["github:bufbuild/protovalidate"],
+  "repository": [
+    "github:bufbuild/protovalidate"
+  ],
   "versions": [],
   "yanked_versions": {}
 }

--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   publish:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@c316f1611511a40423572303f66c80bb30bfe2f8 # v1.4.1
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
     with:
       draft: false
       tag_name: ${{ inputs.tag_name || github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
               sha: toolsCommitTag.data.sha,
             });
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@1d798ff015ed0696433e01e2c3ccbb2abefadad7 # v7.7.0
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.7.0
     needs: create-release-tag
     with:
       release_files: protovalidate-*.tar.gz


### PR DESCRIPTION
The bazel actions break upstream in the BCR release process if they're pinned to a git commit instead of a tag.

See https://github.com/bufbuild/rules_buf/pull/145 for a similar fix.