### PR TITLE
Rename protovalidate-python to protovalidate-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To start using Protovalidate in your projects, see the [developer quickstart][qu
 
 - [`protovalidate-go`][pv-go] (Go)
 - [`protovalidate-java`][pv-java] (Java)
-- [`protovalidate-python`][pv-python] (Python)
+- [`protovalidate-py`][pv-python] (Python)
 - [`protovalidate-cc`][pv-cc] (C++)
 - [`protovalidate-es`][pv-es] (TypeScript and JavaScript)
 
@@ -68,7 +68,7 @@ Offered under the [Apache 2 license][license].
 
 [pv-go]: https://github.com/bufbuild/protovalidate-go
 [pv-java]: https://github.com/bufbuild/protovalidate-java
-[pv-python]: https://github.com/bufbuild/protovalidate-python
+[pv-python]: https://github.com/bufbuild/protovalidate-py
 [pv-cc]: https://github.com/bufbuild/protovalidate-cc
 [pv-es]: https://github.com/bufbuild/protovalidate-es
 

--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -40,7 +40,7 @@ syntax = "proto2";
 // [Go](https://github.com/bufbuild/protovalidate-go),
 // [JavaScript/TypeScript](https://github.com/bufbuild/protovalidate-es),
 // [Java](https://github.com/bufbuild/protovalidate-java),
-// [Python](https://github.com/bufbuild/protovalidate-python),
+// [Python](https://github.com/bufbuild/protovalidate-py),
 // or [C++](https://github.com/bufbuild/protovalidate-cc).
 package buf.validate;
 

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -44,7 +44,7 @@
 // [Go](https://github.com/bufbuild/protovalidate-go),
 // [JavaScript/TypeScript](https://github.com/bufbuild/protovalidate-es),
 // [Java](https://github.com/bufbuild/protovalidate-java),
-// [Python](https://github.com/bufbuild/protovalidate-python),
+// [Python](https://github.com/bufbuild/protovalidate-py),
 // or [C++](https://github.com/bufbuild/protovalidate-cc).
 
 package validate


### PR DESCRIPTION
We will rename the repo to match up with our `py` ecosystem, this PR is to get ready to merge _after_ the rename.