### PR TITLE
Pin buf-action version and reformat protos to 1.72.0

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -14,5 +14,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: bufbuild/buf-action@v1
         with:
+          version: "1.72.0"
           token: ${{ secrets.BUF_TOKEN }}
           push: ${{ github.ref != 'refs/heads/main' && github.event_name == 'push' }}

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/enums.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/enums.proto
@@ -75,10 +75,14 @@ message EnumAliasIn {
 }
 
 message EnumNotIn {
-  TestEnum val = 1 [(buf.validate.field).enum = {not_in: [1]}];
+  TestEnum val = 1 [(buf.validate.field).enum = {
+    not_in: [1]
+  }];
 }
 message EnumAliasNotIn {
-  TestEnumAlias val = 1 [(buf.validate.field).enum = {not_in: [1]}];
+  TestEnumAlias val = 1 [(buf.validate.field).enum = {
+    not_in: [1]
+  }];
 }
 
 message EnumExternal {

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/kitchen_sink.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/kitchen_sink.proto
@@ -48,8 +48,16 @@ message ComplexTestMsg {
     ]
   }];
   ComplexTestEnum enum_const = 11 [(buf.validate.field).enum.const = 2];
-  google.protobuf.Any any_val = 12 [(buf.validate.field).any = {in: ["type.googleapis.com/google.protobuf.Duration"]}];
-  repeated google.protobuf.Timestamp rep_ts_val = 13 [(buf.validate.field).repeated = {items: {timestamp: {gte: {nanos: 1000000}}}}];
+  google.protobuf.Any any_val = 12 [(buf.validate.field).any = {
+    in: ["type.googleapis.com/google.protobuf.Duration"]
+  }];
+  repeated google.protobuf.Timestamp rep_ts_val = 13 [(buf.validate.field).repeated = {
+    items: {
+      timestamp: {
+        gte: {nanos: 1000000}
+      }
+    }
+  }];
   map<sint32, string> map_val = 14 [(buf.validate.field).map.keys.sint32.lt = 0];
   bytes bytes_val = 15 [(buf.validate.field).bytes.const = "\x00\x99"];
   oneof o {

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/messages.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/messages.proto
@@ -55,7 +55,9 @@ message MessageRequiredOneof {
 message MessageWith3dInside {}
 
 message MessageOneofSingleField {
-  option (buf.validate.message).oneof = {fields: ["str_field"]};
+  option (buf.validate.message).oneof = {
+    fields: ["str_field"]
+  };
   string str_field = 1;
   bool bool_field = 2;
 }
@@ -113,7 +115,9 @@ message MessageOneofMultipleSharedFields {
 }
 
 message MessageOneofUnknownFieldName {
-  option (buf.validate.message).oneof = {fields: ["xxx"]};
+  option (buf.validate.message).oneof = {
+    fields: ["xxx"]
+  };
   string str_field = 1;
 }
 
@@ -130,7 +134,9 @@ message MessageOneofDuplicateField {
 }
 
 message MessageOneofZeroFields {
-  option (buf.validate.message).oneof = {fields: []};
+  option (buf.validate.message).oneof = {
+    fields: []
+  };
   string str_field = 1;
   bool bool_field = 2;
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/numbers.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/numbers.proto
@@ -33,7 +33,9 @@ message FloatIn {
   }];
 }
 message FloatNotIn {
-  float val = 1 [(buf.validate.field).float = {not_in: [0]}];
+  float val = 1 [(buf.validate.field).float = {
+    not_in: [0]
+  }];
 }
 message FloatLT {
   float val = 1 [(buf.validate.field).float.lt = 0];
@@ -110,7 +112,9 @@ message DoubleIn {
   }];
 }
 message DoubleNotIn {
-  double val = 1 [(buf.validate.field).double = {not_in: [0]}];
+  double val = 1 [(buf.validate.field).double = {
+    not_in: [0]
+  }];
 }
 message DoubleLT {
   double val = 1 [(buf.validate.field).double.lt = 0];
@@ -187,7 +191,9 @@ message Int32In {
   }];
 }
 message Int32NotIn {
-  int32 val = 1 [(buf.validate.field).int32 = {not_in: [0]}];
+  int32 val = 1 [(buf.validate.field).int32 = {
+    not_in: [0]
+  }];
 }
 message Int32LT {
   int32 val = 1 [(buf.validate.field).int32.lt = 0];
@@ -258,7 +264,9 @@ message Int64In {
   }];
 }
 message Int64NotIn {
-  int64 val = 1 [(buf.validate.field).int64 = {not_in: [0]}];
+  int64 val = 1 [(buf.validate.field).int64 = {
+    not_in: [0]
+  }];
 }
 message Int64LT {
   int64 val = 1 [(buf.validate.field).int64.lt = 0];
@@ -354,7 +362,9 @@ message UInt32In {
   }];
 }
 message UInt32NotIn {
-  uint32 val = 1 [(buf.validate.field).uint32 = {not_in: [0]}];
+  uint32 val = 1 [(buf.validate.field).uint32 = {
+    not_in: [0]
+  }];
 }
 message UInt32LT {
   uint32 val = 1 [(buf.validate.field).uint32.lt = 5];
@@ -425,7 +435,9 @@ message UInt64In {
   }];
 }
 message UInt64NotIn {
-  uint64 val = 1 [(buf.validate.field).uint64 = {not_in: [0]}];
+  uint64 val = 1 [(buf.validate.field).uint64 = {
+    not_in: [0]
+  }];
 }
 message UInt64LT {
   uint64 val = 1 [(buf.validate.field).uint64.lt = 5];
@@ -496,7 +508,9 @@ message SInt32In {
   }];
 }
 message SInt32NotIn {
-  sint32 val = 1 [(buf.validate.field).sint32 = {not_in: [0]}];
+  sint32 val = 1 [(buf.validate.field).sint32 = {
+    not_in: [0]
+  }];
 }
 message SInt32LT {
   sint32 val = 1 [(buf.validate.field).sint32.lt = 0];
@@ -567,7 +581,9 @@ message SInt64In {
   }];
 }
 message SInt64NotIn {
-  sint64 val = 1 [(buf.validate.field).sint64 = {not_in: [0]}];
+  sint64 val = 1 [(buf.validate.field).sint64 = {
+    not_in: [0]
+  }];
 }
 message SInt64LT {
   sint64 val = 1 [(buf.validate.field).sint64.lt = 0];
@@ -637,7 +653,9 @@ message Fixed32In {
   }];
 }
 message Fixed32NotIn {
-  fixed32 val = 1 [(buf.validate.field).fixed32 = {not_in: [0]}];
+  fixed32 val = 1 [(buf.validate.field).fixed32 = {
+    not_in: [0]
+  }];
 }
 message Fixed32LT {
   fixed32 val = 1 [(buf.validate.field).fixed32.lt = 5];
@@ -708,7 +726,9 @@ message Fixed64In {
   }];
 }
 message Fixed64NotIn {
-  fixed64 val = 1 [(buf.validate.field).fixed64 = {not_in: [0]}];
+  fixed64 val = 1 [(buf.validate.field).fixed64 = {
+    not_in: [0]
+  }];
 }
 message Fixed64LT {
   fixed64 val = 1 [(buf.validate.field).fixed64.lt = 5];
@@ -779,7 +799,9 @@ message SFixed32In {
   }];
 }
 message SFixed32NotIn {
-  sfixed32 val = 1 [(buf.validate.field).sfixed32 = {not_in: [0]}];
+  sfixed32 val = 1 [(buf.validate.field).sfixed32 = {
+    not_in: [0]
+  }];
 }
 message SFixed32LT {
   sfixed32 val = 1 [(buf.validate.field).sfixed32.lt = 0];
@@ -850,7 +872,9 @@ message SFixed64In {
   }];
 }
 message SFixed64NotIn {
-  sfixed64 val = 1 [(buf.validate.field).sfixed64 = {not_in: [0]}];
+  sfixed64 val = 1 [(buf.validate.field).sfixed64 = {
+    not_in: [0]
+  }];
 }
 message SFixed64LT {
   sfixed64 val = 1 [(buf.validate.field).sfixed64.lt = 0];

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/repeated.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/repeated.proto
@@ -93,13 +93,19 @@ message RepeatedItemNotIn {
   }];
 }
 message RepeatedEnumIn {
-  repeated AnEnum val = 1 [(buf.validate.field).repeated.items.enum = {in: [0]}];
+  repeated AnEnum val = 1 [(buf.validate.field).repeated.items.enum = {
+    in: [0]
+  }];
 }
 message RepeatedEnumNotIn {
-  repeated AnEnum val = 1 [(buf.validate.field).repeated.items.enum = {not_in: [0]}];
+  repeated AnEnum val = 1 [(buf.validate.field).repeated.items.enum = {
+    not_in: [0]
+  }];
 }
 message RepeatedEmbeddedEnumIn {
-  repeated AnotherInEnum val = 1 [(buf.validate.field).repeated.items.enum = {in: [0]}];
+  repeated AnotherInEnum val = 1 [(buf.validate.field).repeated.items.enum = {
+    in: [0]
+  }];
   enum AnotherInEnum {
     ANOTHER_IN_ENUM_UNSPECIFIED = 0;
     ANOTHER_IN_ENUM_A = 1;
@@ -107,7 +113,9 @@ message RepeatedEmbeddedEnumIn {
   }
 }
 message RepeatedEmbeddedEnumNotIn {
-  repeated AnotherNotInEnum val = 1 [(buf.validate.field).repeated.items.enum = {not_in: [0]}];
+  repeated AnotherNotInEnum val = 1 [(buf.validate.field).repeated.items.enum = {
+    not_in: [0]
+  }];
   enum AnotherNotInEnum {
     ANOTHER_NOT_IN_ENUM_UNSPECIFIED = 0;
     ANOTHER_NOT_IN_ENUM_A = 1;
@@ -115,14 +123,20 @@ message RepeatedEmbeddedEnumNotIn {
   }
 }
 message RepeatedAnyIn {
-  repeated google.protobuf.Any val = 1 [(buf.validate.field).repeated.items.any = {in: ["type.googleapis.com/google.protobuf.Duration"]}];
+  repeated google.protobuf.Any val = 1 [(buf.validate.field).repeated.items.any = {
+    in: ["type.googleapis.com/google.protobuf.Duration"]
+  }];
 }
 message RepeatedAnyNotIn {
-  repeated google.protobuf.Any val = 1 [(buf.validate.field).repeated.items.any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  repeated google.protobuf.Any val = 1 [(buf.validate.field).repeated.items.any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }
 message RepeatedMinAndItemLen {
   repeated string val = 1 [(buf.validate.field).repeated = {
-    items: {string: {len: 3}}
+    items: {
+      string: {len: 3}
+    }
     min_items: 1
   }];
 }
@@ -133,7 +147,13 @@ message RepeatedMinAndMaxItemLen {
   ];
 }
 message RepeatedDuration {
-  repeated google.protobuf.Duration val = 1 [(buf.validate.field).repeated = {items: {duration: {gte: {nanos: 1000000}}}}];
+  repeated google.protobuf.Duration val = 1 [(buf.validate.field).repeated = {
+    items: {
+      duration: {
+        gte: {nanos: 1000000}
+      }
+    }
+  }];
 }
 message RepeatedExactIgnore {
   repeated uint32 val = 1 [

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_any.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_any.proto
@@ -28,26 +28,38 @@ message AnyRequired {
   google.protobuf.Any val = 1 [(buf.validate.field).required = true];
 }
 message AnyIn {
-  google.protobuf.Any val = 1 [(buf.validate.field).any = {in: ["type.googleapis.com/google.protobuf.Duration"]}];
+  google.protobuf.Any val = 1 [(buf.validate.field).any = {
+    in: ["type.googleapis.com/google.protobuf.Duration"]
+  }];
 }
 message AnyNotIn {
-  google.protobuf.Any val = 1 [(buf.validate.field).any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  google.protobuf.Any val = 1 [(buf.validate.field).any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }
 
 // The below messages should throw compilation errors due to incorrect types.
 message AnyWrongTypeScalar {
-  string val = 1 [(buf.validate.field).any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  string val = 1 [(buf.validate.field).any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }
 message AnyWrongTypeMessage {
   message WrongType {
     int32 val = 1;
   }
-  WrongType val = 1 [(buf.validate.field).any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  WrongType val = 1 [(buf.validate.field).any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }
 message AnyWrongTypeWrapper {
-  google.protobuf.Int32Value val = 1 [(buf.validate.field).any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  google.protobuf.Int32Value val = 1 [(buf.validate.field).any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }
 
 message AnyWrongTypeWKT {
-  google.protobuf.Timestamp val = 1 [(buf.validate.field).any = {not_in: ["type.googleapis.com/google.protobuf.Timestamp"]}];
+  google.protobuf.Timestamp val = 1 [(buf.validate.field).any = {
+    not_in: ["type.googleapis.com/google.protobuf.Timestamp"]
+  }];
 }

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_duration.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_duration.proto
@@ -42,7 +42,11 @@ message DurationIn {
   }];
 }
 message DurationNotIn {
-  google.protobuf.Duration val = 1 [(buf.validate.field).duration = {not_in: [{}]}];
+  google.protobuf.Duration val = 1 [(buf.validate.field).duration = {
+    not_in: [
+      {}
+    ]
+  }];
 }
 
 message DurationLT {

--- a/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_field_mask.proto
+++ b/proto/protovalidate-testing/buf/validate/conformance/cases/wkt_field_mask.proto
@@ -27,7 +27,9 @@ message FieldMaskRequired {
 }
 
 message FieldMaskConst {
-  google.protobuf.FieldMask val = 1 [(buf.validate.field).field_mask.const = {paths: ["a"]}];
+  google.protobuf.FieldMask val = 1 [(buf.validate.field).field_mask.const = {
+    paths: ["a"]
+  }];
 }
 
 message FieldMaskIn {
@@ -48,5 +50,7 @@ message FieldMaskNotIn {
 }
 
 message FieldMaskExample {
-  google.protobuf.FieldMask val = 1 [(buf.validate.field).field_mask.example = {paths: ["a"]}];
+  google.protobuf.FieldMask val = 1 [(buf.validate.field).field_mask.example = {
+    paths: ["a"]
+  }];
 }


### PR DESCRIPTION
#510 failed due to the formatting check being non-reproducible CI. I have gone ahead and pinned to the currently used version (latest version) to prevent that, and applied the formatting here.

Other approaches would be pin to the 1.66.0 version in the `Makefile` (hard to keep in sync), or replace this entirely with a `make` command. Let me know if any preference.