### PR TITLE
Don't run buf-ci push job in forks

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -9,6 +9,7 @@ permissions:
   pull-requests: write
 jobs:
   buf:
+    if: github.repository == 'bufbuild/protovalidate'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Currently this workflow always fails on a push event in the fork repo, like

https://github.com/anuraaga/protovalidate/actions/runs/32110482296

This preserves handling push events in this repo while allowing contributor forks to not go red. Note, personally it's a bit confusing the same workflow [runs](https://github.com/bufbuild/protovalidate/actions/runs/29038902667) [twice](https://github.com/bufbuild/protovalidate/actions/runs/29038889737) on PRs for branches in this repo - I think reworking to restricting push to `main` and configuring the job to format/lint/push appropriately could be cleaner but took the easy approach for now.