### PR TITLE
Updates doc links to use protovalidate.com

### DIFF
--- a/proto/protovalidate/buf/validate/validate.proto
+++ b/proto/protovalidate/buf/validate/validate.proto
@@ -105,7 +105,7 @@ extend google.protobuf.FieldOptions {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+// information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 // message Foo {
@@ -145,7 +145,7 @@ message MessageRules {
   // simpler syntax when defining CEL Rules where `id` and `message` derived from the `expression`. `id` will
   // be same as the `expression`.
   //
-  // For more information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // For more information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   // ```proto
   // message MyMessage {
@@ -159,7 +159,7 @@ message MessageRules {
   repeated string cel_expression = 5;
   // `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
   // These rules are written in Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   //
   // ```proto
@@ -256,7 +256,7 @@ message FieldRules {
   // simpler syntax when defining CEL Rules where `id` and `message` derived from the `expression`. `id` will
   // be same as the `expression`.
   //
-  // For more information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // For more information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   // ```proto
   // message MyMessage {
@@ -267,7 +267,7 @@ message FieldRules {
   repeated string cel_expression = 29;
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/custom-rules/).
   //
   // ```proto
   // message MyMessage {
@@ -390,7 +390,7 @@ message FieldRules {
 message PredefinedRules {
   // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information,
-  // [see our documentation](https://buf.build/docs/protovalidate/schemas/predefined-rules/).
+  // [see our documentation](https://protovalidate.com/schemas/predefined-rules/).
   //
   // ```proto
   // message MyMessage {

--- a/tools/internal/gen/buf/validate/validate.pb.go
+++ b/tools/internal/gen/buf/validate/validate.pb.go
@@ -277,7 +277,7 @@ func (KnownRegex) EnumDescriptor() ([]byte, []int) {
 // `Rule` represents a validation rule written in the Common Expression
 // Language (CEL) syntax. Each Rule includes a unique identifier, an
 // optional error message, and the CEL expression to evaluate. For more
-// information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+// information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 //
 // ```proto
 //
@@ -372,7 +372,7 @@ type MessageRules struct {
 	// simpler syntax when defining CEL Rules where `id` and `message` derived from the `expression`. `id` will
 	// be same as the `expression`.
 	//
-	// For more information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// For more information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -388,7 +388,7 @@ type MessageRules struct {
 	CelExpression []string `protobuf:"bytes,5,rep,name=cel_expression,json=celExpression" json:"cel_expression,omitempty"`
 	// `cel` is a repeated field of type Rule. Each Rule specifies a validation rule to be applied to this message.
 	// These rules are written in Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -627,7 +627,7 @@ type FieldRules struct {
 	// simpler syntax when defining CEL Rules where `id` and `message` derived from the `expression`. `id` will
 	// be same as the `expression`.
 	//
-	// For more information, [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// For more information, [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -640,7 +640,7 @@ type FieldRules struct {
 	CelExpression []string `protobuf:"bytes,29,rep,name=cel_expression,json=celExpression" json:"cel_expression,omitempty"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/custom-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/custom-rules/).
 	//
 	// ```proto
 	//
@@ -1166,7 +1166,7 @@ type PredefinedRules struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// `cel` is a repeated field used to represent a textual expression
 	// in the Common Expression Language (CEL) syntax. For more information,
-	// [see our documentation](https://buf.build/docs/protovalidate/schemas/predefined-rules/).
+	// [see our documentation](https://protovalidate.com/schemas/predefined-rules/).
 	//
 	// ```proto
 	//


### PR DESCRIPTION
I'm not sure if there's more ceremony needed for this, but since the docs moved a while ago it'll be good to use the canonical URLs for the docs and not rely on redirects.